### PR TITLE
Passing of GitHUB_TOKEN as secret

### DIFF
--- a/containers/pytorch/training/gpu/2.1/transformers/4.38.0.dev0/README.md
+++ b/containers/pytorch/training/gpu/2.1/transformers/4.38.0.dev0/README.md
@@ -18,7 +18,8 @@ Use the following command to build the docker image. Make sure to replace the va
 ```bash
 git clone https://github.com/huggingface/Google-Cloud-Containers
 cd Google-Cloud-Containers
-docker build --build-arg="GITHUB_TOKEN=xxxxx" -t pytorch-training-gpu.2.1.transformers.4.38.0.dev0.py310 -f containers/pytorch/training/gpu/2.1/transformers/4.38.0.dev0/py310/Dockerfile .
+export GITHUB_TOKEN=your-github-token
+docker build --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN -t pytorch-training-gpu.2.1.transformers.4.38.0.dev0.py310 -f containers/pytorch/training/gpu/2.1/transformers/4.38.0.dev0/py310/Dockerfile .
 ```
 
 For setting the value of `GITHUB_TOKEN` please follow the detailed instructions mentioned in the following links: 

--- a/containers/pytorch/training/gpu/2.1/transformers/4.38.0.dev0/py310/Dockerfile
+++ b/containers/pytorch/training/gpu/2.1/transformers/4.38.0.dev0/py310/Dockerfile
@@ -6,9 +6,6 @@ LABEL maintainer="Hugging Face"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Versions
-
-#Mandatory GitHub token to access the private repository, read more about it here: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-ARG GITHUB_TOKEN
 ARG FLASH_ATTN='2.5.2'
 ARG TRANSFORMERS='4.37.2'
 ARG DIFFUSERS='0.26.1'
@@ -66,7 +63,8 @@ RUN pip install --upgrade --no-cache-dir \
   bitsandbytes==${BITSANDBYTES}
 
 # To install version that has golden-gate integrated into transformers
-RUN pip install git+https://${GITHUB_TOKEN}@github.com/huggingface/new-model-addition-golden-gate.git@add-golden-gate
+#Mandatory GitHub token to access the private repository, read more about it here: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+RUN --mount=type=secret,id=GITHUB_TOKEN pip install git+https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/huggingface/new-model-addition-golden-gate.git@add-golden-gate
 
 # Install Google Cloud Dependencies
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \


### PR DESCRIPTION
This PR removes passing of GITHUB_TOKEN as an ARG and passes it as a SECRET. 