### PR TITLE
Copy `Cargo.lock` file to avoid installation issues

### DIFF
--- a/containers/tgi/gpu/2.0.0/Dockerfile
+++ b/containers/tgi/gpu/2.0.0/Dockerfile
@@ -13,6 +13,7 @@ ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 FROM chef as planner
 COPY --from=tgi /tgi/Cargo.toml Cargo.toml
+COPY --from=tgi /tgi/Cargo.lock Cargo.lock
 COPY --from=tgi /tgi/rust-toolchain.toml rust-toolchain.toml
 COPY --from=tgi /tgi/proto proto
 COPY --from=tgi /tgi/benchmark benchmark

--- a/containers/tgi/gpu/2.0.1/Dockerfile
+++ b/containers/tgi/gpu/2.0.1/Dockerfile
@@ -13,6 +13,7 @@ ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 FROM chef as planner
 COPY --from=tgi /tgi/Cargo.toml Cargo.toml
+COPY --from=tgi /tgi/Cargo.lock Cargo.lock
 COPY --from=tgi /tgi/rust-toolchain.toml rust-toolchain.toml
 COPY --from=tgi /tgi/proto proto
 COPY --from=tgi /tgi/benchmark benchmark

--- a/containers/tgi/gpu/2.0.3/Dockerfile
+++ b/containers/tgi/gpu/2.0.3/Dockerfile
@@ -13,6 +13,7 @@ ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 FROM chef as planner
 COPY --from=tgi /tgi/Cargo.toml Cargo.toml
+COPY --from=tgi /tgi/Cargo.lock Cargo.lock
 COPY --from=tgi /tgi/rust-toolchain.toml rust-toolchain.toml
 COPY --from=tgi /tgi/proto proto
 COPY --from=tgi /tgi/benchmark benchmark


### PR DESCRIPTION
## Description

This PR adds the `Cargo.lock` file from TGI before running `cargo chef prepare` for the following TGI images:

- `containers/tgi/gpu/2.0.0/Cargo.lock`
- `containers/tgi/gpu/2.0.1/Cargo.lock`
- `containers/tgi/gpu/2.0.3/Cargo.lock`

This prevents the following issue during the `docker build` process of those images (as of late June - July 2024):

```
error: package `bitstream-io v2.4.2` cannot be built because it requires rustc 1.79 or newer, while the currently active rustc version is 1.75.0
Either upgrade to rustc 1.79 or newer, or use
cargo update bitstream-io@2.4.2 --precise ver
where `ver` is the latest version of `bitstream-io` supporting rustc 1.75.0
thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-chef-0.1.62/src/recipe.rs:204:27:
Exited with status code: 101
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```