### PR TITLE
Fix `FromAsCasing` warning on `docker build`

### DIFF
--- a/containers/tei/cpu/1.4.0/Dockerfile
+++ b/containers/tei/cpu/1.4.0/Dockerfile
@@ -75,7 +75,7 @@ COPY --from=tei /tei/proto proto
 
 RUN cargo build --release --bin text-embeddings-router -F google -F grpc -F candle -F mkl-dynamic --no-default-features && sccache -s
 
-FROM debian:bookworm-slim as base
+FROM debian:bookworm-slim AS base
 
 ENV HUGGINGFACE_HUB_CACHE=/tmp \
     PORT=8080 \

--- a/containers/tei/gpu/1.4.0/Dockerfile
+++ b/containers/tei/gpu/1.4.0/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=planner /usr/src/recipe.json recipe.json
 
 RUN cargo chef cook --release --features google --recipe-path recipe.json && sccache -s
 
-FROM builder as builder-75
+FROM builder AS builder-75
 
 RUN CUDA_COMPUTE_CAP=75 cargo chef cook --release --features google --features candle-cuda-turing --recipe-path recipe.json && sccache -s
 
@@ -70,7 +70,7 @@ COPY --from=tei /tei/Cargo.lock ./
 
 RUN CUDA_COMPUTE_CAP=75 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F google && sccache -s
 
-FROM builder as builder-80
+FROM builder AS builder-80
 
 RUN CUDA_COMPUTE_CAP=80 cargo chef cook --release --features google --features candle-cuda --recipe-path recipe.json && sccache -s
 
@@ -82,7 +82,7 @@ COPY --from=tei /tei/Cargo.lock ./
 
 RUN CUDA_COMPUTE_CAP=80 cargo build --release --bin text-embeddings-router -F candle-cuda -F google && sccache -s
 
-FROM builder as builder-90
+FROM builder AS builder-90
 
 RUN CUDA_COMPUTE_CAP=90 cargo chef cook --release --features google --features candle-cuda --recipe-path recipe.json && sccache -s
 
@@ -94,7 +94,7 @@ COPY --from=tei /tei/Cargo.lock ./
 
 RUN CUDA_COMPUTE_CAP=90 cargo build --release --bin text-embeddings-router -F candle-cuda -F google && sccache -s
 
-FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 as base
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS base
 
 ARG DEFAULT_USE_FLASH_ATTENTION=True
 


### PR DESCRIPTION
## Description

This PR fixes a warning that is raised during the `docker build` process due to mismatching formatting in the `FROM` and `AS` keywords (set to upper and lower case, respectively).

See the warnings raised on `docker build` of the TEI GPU container below:

```
4 warnings found (use --debug to expand):
FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 61)
FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 73)
FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 85)
FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 97)
```