### PR TITLE
Add reference to Google Cloud DLCs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains container files for building Hugging Face specific Deep
 | us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-inference-cpu.2-2.transformers.4-41.ubuntu2204.py311 | [huggingface-pytorch-inference-cpu.2.2.2.transformers.4.41.1.py311](./containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile) | PyTorch | Inference | CPU |
 
 > [!NOTE]
-> The listing above only contains the latest version of each of the Hugging Face DLCs, the full listing of the available published containers in Google Cloud can be found either in the [Google Cloud Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or via the `gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platform-release/gcr.io" | grep "huggingface-"` command.
+> The listing above only contains the latest version of each of the Hugging Face DLCs, the full listing of the available published containers in Google Cloud can be found either in the [Deep Learning Containers Documentation](https://cloud.google.com/deep-learning-containers/docs/choosing-container#hugging-face), in the [Google Cloud Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or via the `gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platform-release/gcr.io" | grep "huggingface-"` command.
 
 ## Examples
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -4,7 +4,7 @@ This directory contains the Hugging Face Deep Learning Containers (DLCs) availab
 
 Additionally, the [`container.yaml`](./container.yaml) file contains the configuration for the latest version of each container. Google uses this file to determine which container to build as of the latest version, but can also be used as a reference on the latest available containers.
 
-Find all the available Hugging Face DLCs in either [Google Cloud's Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or list those using the following `gcloud` command that lists the containers with the tag containing `huggingface-` as follows:
+Find all the available Hugging Face DLCs in either the [Google Cloud Deep Learning Containers Documentation](https://cloud.google.com/deep-learning-containers/docs/choosing-container#hugging-face), in the [Google Cloud Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or via the following `gcloud` command that lists all the available DLCs on Google Cloud, filtering by the `huggingface-` tag:
 
 ```bash
 gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platform-release/gcr.io" | grep "huggingface"

--- a/containers/pytorch/inference/README.md
+++ b/containers/pytorch/inference/README.md
@@ -11,7 +11,7 @@ The `huggingface-inference-toolkit` provides default pre-processing, predict and
 
 ## Published Containers
 
-In order to check which of the available Hugging Face DLCs are published, one can either check [Google Cloud's Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag containing `huggingface-pytorch-inference` as follows:
+To check which of the available Hugging Face DLCs are published, you can either check the [Google Cloud Deep Learning Containers Documentation for PyTorch Inference](https://cloud.google.com/deep-learning-containers/docs/choosing-container#pytorch-inference), the [Google Cloud Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag `huggingface-pytorch-inference` as follows:
 
 ```bash
 gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platform-release/gcr.io" | grep "huggingface-pytorch-inference"

--- a/containers/pytorch/training/README.md
+++ b/containers/pytorch/training/README.md
@@ -7,7 +7,7 @@ The Hugging Face PyTorch Training Containers are Docker containers for training 
 
 ## Published Containers
 
-In order to check which of the available Hugging Face DLCs are published, you can either check [Google Cloud's Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag containing `huggingface-pytorch-training` as follows:
+To check which of the available Hugging Face DLCs are published, you can either check the [Google Cloud Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag `huggingface-pytorch-training` as follows:
 
 ```bash
 gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platform-release/gcr.io" | grep "huggingface-pytorch-training"

--- a/containers/tei/README.md
+++ b/containers/tei/README.md
@@ -4,7 +4,7 @@
 
 ## Published Containers
 
-In order to check which of the available Hugging Face DLCs are published, one can either check [Google Cloud's Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag containing `huggingface-text-embeddings-inference` as follows:
+To check which of the available Hugging Face DLCs are published, you can either check the [Google Cloud Deep Learning Containers Documentation for TEI](https://cloud.google.com/deep-learning-containers/docs/choosing-container#text-embeddings-inference), the [Google Cloud Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag `huggingface-text-embeddings-inference` as follows:
 
 ```bash
 gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platform-release/gcr.io" | grep "huggingface-text-embeddings-inference"

--- a/containers/tgi/README.md
+++ b/containers/tgi/README.md
@@ -4,7 +4,7 @@
 
 ## Published Containers
 
-In order to check which of the available Hugging Face DLCs are published, one can either check [Google Cloud's Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag containing `huggingface-text-generation-inference` as follows:
+To check which of the available Hugging Face DLCs are published, you can either check the [Google Cloud Deep Learning Containers Documentation for TGI](https://cloud.google.com/deep-learning-containers/docs/choosing-container#text-generation-inference), the [Google Cloud Artifact Registry](https://console.cloud.google.com/artifacts/docker/deeplearning-platform-release/us/gcr.io) or use the `gcloud` command to list the available containers with the tag `huggingface-text-generation-inference` as follows:
 
 ```bash
 gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platform-release/gcr.io" | grep "huggingface-text-generation-inference"


### PR DESCRIPTION
## Description

This PR adds the references to the Google Cloud Deep Learning Containers Documentation at https://cloud.google.com/deep-learning-containers/docs/choosing-container#hugging-face, as it contains a listing of the available published containers in Google Cloud too.

Kudos @philschmid on sharing the URL.