### PR TITLE
Revision some `README.md` and `vertex-notebook.ipynb` files

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -12,10 +12,10 @@ gcloud container images list --repository="us-docker.pkg.dev/deeplearning-platfo
 
 For more information on each container, check the READMEs in the following directories
 
-* [Text Generation Inference](./tgi/README.md)
-* [Text Embeddings Inference](./tei/README.md)
-* [PyTorch Inference](./pytorch/inference/README.md)
-* [PyTorch Training](./pytorch/training/README.md)
+- [Text Generation Inference](./tgi/README.md)
+- [Text Embeddings Inference](./tei/README.md)
+- [PyTorch Inference](./pytorch/inference/README.md)
+- [PyTorch Training](./pytorch/training/README.md)
 
 ## Directory Structure
 

--- a/containers/pytorch/training/README.md
+++ b/containers/pytorch/training/README.md
@@ -23,46 +23,46 @@ Additionally, if you're willing to run the Docker container in GPUs you will nee
 
 The PyTorch Training containers will start a training job that will start on `docker run` and will be closed whenever the training job finishes. As the container is offered for both accelerators GPU and TPU, the examples below are provided.
 
-* **GPU**: This example showcases how to fine-tune an LLM via [`trl`](https://github.com/huggingface/trl) on a GPU instance using the PyTorch Training container, as it comes with `trl` installed.
+- **GPU**: This example showcases how to fine-tune an LLM via [`trl`](https://github.com/huggingface/trl) on a GPU instance using the PyTorch Training container, as it comes with `trl` installed.
 
-    ```bash
-    docker run --gpus all -ti \
-        -v $(pwd)/artifact:/artifact \
-        -e HF_TOKEN=$(cat ~/.cache/huggingface/token) \
-        us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-gpu.2.3.0.transformers.4.42.3.py310 \
-        trl sft \
-        --model_name_or_path google/gemma-2b \
-        --attn_implementation "flash_attention_2" \
-        --torch_dtype "bfloat16" \
-        --dataset_name OpenAssistant/oasst_top1_2023-08-25 \
-        --dataset_text_field "text" \
-        --max_steps 100 \
-        --logging_steps 10 \
-        --bf16 True \
-        --per_device_train_batch_size 4 \
-        --use_peft True \
-        --load_in_4bit True \
-        --output_dir /artifacts
-    ```
+  ```bash
+  docker run --gpus all -ti \
+      -v $(pwd)/artifact:/artifact \
+      -e HF_TOKEN=$(cat ~/.cache/huggingface/token) \
+      us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-gpu.2.3.0.transformers.4.42.3.py310 \
+      trl sft \
+      --model_name_or_path google/gemma-2b \
+      --attn_implementation "flash_attention_2" \
+      --torch_dtype "bfloat16" \
+      --dataset_name OpenAssistant/oasst_top1_2023-08-25 \
+      --dataset_text_field "text" \
+      --max_steps 100 \
+      --logging_steps 10 \
+      --bf16 True \
+      --per_device_train_batch_size 4 \
+      --use_peft True \
+      --load_in_4bit True \
+      --output_dir /artifacts
+  ```
 
-    > [!NOTE]
-    > For a more detailed explanation and a diverse set of examples, please check the [./examples](../../examples) directory that contains examples on both Google Kubernetes Engine (GKE) and Google Vertex AI.
+  > [!NOTE]
+  > For a more detailed explanation and a diverse set of examples, please check the [./examples](../../examples) directory that contains examples on both Google Kubernetes Engine (GKE) and Google Vertex AI.
 
-* **TPU**: This example showcases how to deploy a Jupyter Notebook Server from a TPU instance (such as `v5litepod-8`) using the PyTorch Training container, as it comes with `optimum-tpu` installed; so that then you can import a Jupyter Notebook from the ones defined within the `opitimum-tpu` repository or just reuse the Jupyter Notebook that comes within the PyTorch Training container i.e. [`gemma-tuning.ipynb`](https://github.com/huggingface/optimum-tpu/blob/main/examples/language-modeling/gemma_tuning.ipynb); and then just run it.
+- **TPU**: This example showcases how to deploy a Jupyter Notebook Server from a TPU instance (such as `v5litepod-8`) using the PyTorch Training container, as it comes with `optimum-tpu` installed; so that then you can import a Jupyter Notebook from the ones defined within the `opitimum-tpu` repository or just reuse the Jupyter Notebook that comes within the PyTorch Training container i.e. [`gemma-tuning.ipynb`](https://github.com/huggingface/optimum-tpu/blob/main/examples/language-modeling/gemma_tuning.ipynb); and then just run it.
 
-    ```bash
-    docker run --rm --net host --privileged \
-        -v$(pwd)/artifact:/notebooks/output \
-        us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-tpu.2.4.0.transformers.4.41.1.py310 \
-        jupyter notebook \
-        --port 8888 \
-        --allow-root \
-        --no-browser \
-        notebooks
-    ```
+  ```bash
+  docker run --rm --net host --privileged \
+      -v$(pwd)/artifact:/notebooks/output \
+      us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-tpu.2.4.0.transformers.4.41.1.py310 \
+      jupyter notebook \
+      --port 8888 \
+      --allow-root \
+      --no-browser \
+      notebooks
+  ```
 
-    > [!NOTE]
-    > Find more detailed examples on TPU fine-tuning in the [`optimum-tpu`](https://github.com/huggingface/optimum-tpu/tree/main/examples) repository.
+  > [!NOTE]
+  > Find more detailed examples on TPU fine-tuning in the [`optimum-tpu`](https://github.com/huggingface/optimum-tpu/tree/main/examples) repository.
 
 ## Optional
 
@@ -73,14 +73,14 @@ The PyTorch Training containers will start a training job that will start on `do
 
 The PyTorch Training containers come with two different containers depending on the accelerator used for training, being either GPU or TPU, those have different constraints when building the Docker image as described below:
 
-* **GPU**: To build the PyTorch Training container for GPU, an instance with at least one NVIDIA GPU available is required to install `flash-attn` (used to speed up the attention layers during training and inference).
+- **GPU**: To build the PyTorch Training container for GPU, an instance with at least one NVIDIA GPU available is required to install `flash-attn` (used to speed up the attention layers during training and inference).
 
-    ```bash
-    docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-gpu.2.3.0.transformers.4.42.3.py310 -f containers/pytorch/training/gpu/2.3.0/transformers/4.42.3/py310/Dockerfile .
-    ```
+  ```bash
+  docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-gpu.2.3.0.transformers.4.42.3.py310 -f containers/pytorch/training/gpu/2.3.0/transformers/4.42.3/py310/Dockerfile .
+  ```
 
-* **TPU**: To build the PyTorch Training container for Google Cloud TPUs, an instance with at least one TPU available is required to install `optimum-tpu` which is a Python library with Google TPU optimizations for `transformers` models, making its integration seamless.
+- **TPU**: To build the PyTorch Training container for Google Cloud TPUs, an instance with at least one TPU available is required to install `optimum-tpu` which is a Python library with Google TPU optimizations for `transformers` models, making its integration seamless.
 
-    ```bash
-    docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-tpu.2.4.0.transformers.4.41.1.py310 -f containers/pytorch/training/tpu/2.4.0/transformers/4.41.1/py310/Dockerfile .
-    ```
+  ```bash
+  docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-training-tpu.2.4.0.transformers.4.41.1.py310 -f containers/pytorch/training/tpu/2.4.0/transformers/4.41.1/py310/Dockerfile .
+  ```

--- a/containers/tei/README.md
+++ b/containers/tei/README.md
@@ -24,29 +24,29 @@ To run this DLC, you need to first define the model to deploy i.e. any model fro
 
 Besides selecting which model to deploy, to take into consideration that TEI supports the following models:
 
-* **Text Embeddings**: these are models are pre-trained models that convert text into numerical vectors, which can be used for a variety of downstream tasks.
+- **Text Embeddings**: these are models are pre-trained models that convert text into numerical vectors, which can be used for a variety of downstream tasks.
 
-* **Re-Rankers**: these models are sequence classification cross-encoders models with a single class that scores the similarity between a query and a text.
+- **Re-Rankers**: these models are sequence classification cross-encoders models with a single class that scores the similarity between a query and a text.
 
-* **Sequence Classification**: these models are classic sequence classification models as e.g. BERT, RoBERTa, etc.
+- **Sequence Classification**: these models are classic sequence classification models as e.g. BERT, RoBERTa, etc.
 
 Then eady to run the container depending on the accelerator to use as follows:
 
-* **CPU**: To run  the image on a CPU instance, you need to provide the `MODEL_ID` environment variable and expose the port 8080.
+- **CPU**: To run the image on a CPU instance, you need to provide the `MODEL_ID` environment variable and expose the port 8080.
 
-    ```bash
-    docker run -ti -p 8080:8080 \
-        -e MODEL_ID=BAAI/bge-large-en-v1.5 \
-        us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-cpu.1.4.0
-    ```
+  ```bash
+  docker run -ti -p 8080:8080 \
+      -e MODEL_ID=BAAI/bge-large-en-v1.5 \
+      us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-cpu.1.4.0
+  ```
 
-* **GPU**: To run the image on a GPU instance, you need to also add `--gpus all` so that the container can access the GPUs, and then provide the `MODEL_ID` environment variable and expose the port 8080.
+- **GPU**: To run the image on a GPU instance, you need to also add `--gpus all` so that the container can access the GPUs, and then provide the `MODEL_ID` environment variable and expose the port 8080.
 
-    ```bash
-    docker run -ti --gpus all -p 8080:8080 \
-        -e MODEL_ID=BAAI/bge-large-en-v1.5 \
-        us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-gpu.1.4.0
-    ```
+  ```bash
+  docker run -ti --gpus all -p 8080:8080 \
+      -e MODEL_ID=BAAI/bge-large-en-v1.5 \
+      us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-gpu.1.4.0
+  ```
 
 ### Test
 
@@ -57,32 +57,32 @@ Once the Docker container is running, as it has been deployed with `text-embeddi
 
 Depending on the model that has been deployed the inference endpoints will be:
 
-* `/embed`: generates the embeddings for the input text.
+- `/embed`: generates the embeddings for the input text.
 
-    ```bash
-    curl 0.0.0.0:8080/embed \
-        -X POST \
-        -d '{"inputs":"Deep Learning is a"}' \
-        -H 'Content-Type: application/json'
-    ```
+  ```bash
+  curl 0.0.0.0:8080/embed \
+      -X POST \
+      -d '{"inputs":"Deep Learning is a"}' \
+      -H 'Content-Type: application/json'
+  ```
 
-* `/rerank`: ranks the similarity between a query and a list of texts.
+- `/rerank`: ranks the similarity between a query and a list of texts.
 
-    ```bash
-    curl 0.0.0.0:8080/rerank \
-        -X POST \
-        -d '{"query":"Deep Learning is a","texts":["Machine Learning is a","Deep Learning is a","Deep Learning is a subset of Machine Learning"]}' \
-        -H 'Content-Type: application/json'
-    ```
+  ```bash
+  curl 0.0.0.0:8080/rerank \
+      -X POST \
+      -d '{"query":"Deep Learning is a","texts":["Machine Learning is a","Deep Learning is a","Deep Learning is a subset of Machine Learning"]}' \
+      -H 'Content-Type: application/json'
+  ```
 
-* `/predict`: predicts the class of the input text.
+- `/predict`: predicts the class of the input text.
 
-    ```bash
-    curl 0.0.0.0:8080/predict \
-        -X POST \
-        -d '{"inputs":"Deep Learning is a subset of Machine Learning"}' \
-        -H 'Content-Type: application/json'
-    ```
+  ```bash
+  curl 0.0.0.0:8080/predict \
+      -X POST \
+      -d '{"inputs":"Deep Learning is a subset of Machine Learning"}' \
+      -H 'Content-Type: application/json'
+  ```
 
 > [!NOTE]
 > Additionally, note that both `/embed` for text embeddings models and `/predict` for sequence classification models support batching so that instead of a single instance with `inputs` being a string, a `List[str]` can be provided instead.
@@ -96,14 +96,14 @@ Depending on the model that has been deployed the inference endpoints will be:
 
 Since TEI comes with two different containers depending on the accelerator used for the inference, being either CPU or GPU, those have different constraints when building the Docker image as described below:
 
-* **CPU**: To build TEI for CPU, you will need an instance with enough CPU RAM, but most instances should be able to successfully build the CPU image since it's not too memory-intensive.
+- **CPU**: To build TEI for CPU, you will need an instance with enough CPU RAM, but most instances should be able to successfully build the CPU image since it's not too memory-intensive.
 
-    ```bash
-    docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-cpu.1.4.0 -f containers/tei/cpu/1.4.0/Dockerfile .
-    ```
+  ```bash
+  docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-cpu.1.4.0 -f containers/tei/cpu/1.4.0/Dockerfile .
+  ```
 
-* **GPU**: To build TEI for GPU, you will need an instance with at least 4 NVIDIA GPUs available with at least 24 GiB of VRAM each, since TEI, similarly to TGI, needs to build and compile the kernels required for the optimized inference. Also note that the build process may take ~15 minutes to complete, depending on the instance's specifications.
+- **GPU**: To build TEI for GPU, you will need an instance with at least 4 NVIDIA GPUs available with at least 24 GiB of VRAM each, since TEI, similarly to TGI, needs to build and compile the kernels required for the optimized inference. Also note that the build process may take ~15 minutes to complete, depending on the instance's specifications.
 
-    ```bash
-    docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-gpu.1.4.0 -f containers/tei/gpu/1.4.0/Dockerfile .
-    ```
+  ```bash
+  docker build -t us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-embeddings-inference-gpu.1.4.0 -f containers/tei/gpu/1.4.0/Dockerfile .
+  ```

--- a/examples/gke/README.md
+++ b/examples/gke/README.md
@@ -4,16 +4,16 @@ This directory contains usage examples of the Hugging Face Deep Learning Contain
 
 ## Training Examples
 
-| Example | Description
-|---------|-------------
-| [trl-full-fine-tuning](./trl-full-fine-tuning) | Full SFT fine-tuning of Gemma 2B in a multi-GPU instance with TRL on GKE.
-| [trl-lora-fine-tuning](./trl-lora-fine-tuning) | LoRA SFT fine-tuning of Mistral 7B v0.3 in a single GPU instance with TRL on GKE.
+| Example                                        | Description                                                                       |
+| ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| [trl-full-fine-tuning](./trl-full-fine-tuning) | Full SFT fine-tuning of Gemma 2B in a multi-GPU instance with TRL on GKE.         |
+| [trl-lora-fine-tuning](./trl-lora-fine-tuning) | LoRA SFT fine-tuning of Mistral 7B v0.3 in a single GPU instance with TRL on GKE. |
 
 ## Inference Examples
 
-| Example | Description
-|---------|-------------
-| [tgi-deployment](./tgi-deployment) | Deploying Llama3 8B with Text Generation Inference (TGI) on GKE.
-| [tgi-from-gcs-deployment](./tgi-from-gcs-deployment) | Deploying Qwen2 7B Instruct with Text Generation Inference (TGI) from a GCS Bucket on GKE.
-| [tei-deployment](./tei-deployment) | Deploying Snowflake's Arctic Embed (M) with Text Embeddings Inference (TEI) on GKE.
-| [tei-from-gcs-deployment](./tei-from-gcs-deployment) | Deploying BGE Base v1.5 (English) with Text Embeddings Inference (TEI) from a GCS Bucket on GKE.
+| Example                                              | Description                                                                                      |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [tgi-deployment](./tgi-deployment)                   | Deploying Llama3 8B with Text Generation Inference (TGI) on GKE.                                 |
+| [tgi-from-gcs-deployment](./tgi-from-gcs-deployment) | Deploying Qwen2 7B Instruct with Text Generation Inference (TGI) from a GCS Bucket on GKE.       |
+| [tei-deployment](./tei-deployment)                   | Deploying Snowflake's Arctic Embed (M) with Text Embeddings Inference (TEI) on GKE.              |
+| [tei-from-gcs-deployment](./tei-from-gcs-deployment) | Deploying BGE Base v1.5 (English) with Text Embeddings Inference (TEI) from a GCS Bucket on GKE. |

--- a/examples/gke/tei-deployment/README.md
+++ b/examples/gke/tei-deployment/README.md
@@ -21,6 +21,7 @@ Then you need to login into your GCP account and set the project ID to the one y
 
 ```bash
 gcloud auth login
+gcloud auth application-default login  # For local development
 gcloud config set project $PROJECT_ID
 ```
 

--- a/examples/gke/tei-deployment/README.md
+++ b/examples/gke/tei-deployment/README.md
@@ -6,8 +6,8 @@ Snowflake's Arctic Embed is a suite of text embedding models that focuses on cre
 
 First, you need to install both `gcloud` and `kubectl` in your local machine, which are the command-line tools for Google Cloud and Kubernetes, respectively, to interact with the GCP and the GKE Cluster.
 
-* To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
-* To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
+- To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
+- To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 Optionally, to ease the usage of the commands within this tutorial, you need to set the following environment variables for GCP:
 
@@ -92,9 +92,9 @@ Now you can proceed to the Kubernetes deployment of the Hugging Face DLC for TEI
 
 The Hugging Face DLC for TEI will be deployed via `kubectl`, from the configuration files in either the `cpu-config/` or the `gpu-config/` directories depending on whether you want to use the CPU or GPU accelerators, respectively:
 
-* `deployment.yaml`: contains the deployment details of the pod including the reference to the Hugging Face DLC for TEI setting the `MODEL_ID` to [`Snowflake/snowflake-arctic-embed-m`](https://huggingface.co/Snowflake/snowflake-arctic-embed-m).
-* `service.yaml`: contains the service details of the pod, exposing the port 80 for the TEI service.
-* (optional) `ingress.yaml`: contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
+- `deployment.yaml`: contains the deployment details of the pod including the reference to the Hugging Face DLC for TEI setting the `MODEL_ID` to [`Snowflake/snowflake-arctic-embed-m`](https://huggingface.co/Snowflake/snowflake-arctic-embed-m).
+- `service.yaml`: contains the service details of the pod, exposing the port 80 for the TEI service.
+- (optional) `ingress.yaml`: contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
 kubectl apply -f cpu-config/
@@ -122,25 +122,25 @@ kubectl apply -f cpu-config/
 
 To run the inference over the deployed TEI service, you can either:
 
-* Port-forwarding the deployed TEI service to the port 8080, so as to access via `localhost` with the command:
+- Port-forwarding the deployed TEI service to the port 8080, so as to access via `localhost` with the command:
 
-    ```bash
-    kubectl port-forward service/tei-service 8080:8080
-    ```
+  ```bash
+  kubectl port-forward service/tei-service 8080:8080
+  ```
 
-* Accessing the TEI service via the external IP of the ingress, which is the default scenario here since you have defined the ingress configuration in the `cpu-config/ingress.yaml` or the `gpu-config/ingress.yaml` file (but it can be skipped in favour of the port-forwarding), that can be retrieved with the following command:
+- Accessing the TEI service via the external IP of the ingress, which is the default scenario here since you have defined the ingress configuration in the `cpu-config/ingress.yaml` or the `gpu-config/ingress.yaml` file (but it can be skipped in favour of the port-forwarding), that can be retrieved with the following command:
 
-    ```bash
-    kubectl get ingress tei-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    ```
+  ```bash
+  kubectl get ingress tei-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+  ```
 
 > [!NOTE]
 > TEI exposes different inference endpoints based on the task that the model is serving:
 >
-> * **Text Embeddings**: text embedding models expose the endpoint `/embed` expecting a payload with the key `inputs` which is either a string or a list of strings to be embedded.
-> * **Re-rank**: re-ranker models expose the endpoint `/rerank` expecting a payload with the keys `query` and `texts`, where the `query` is the reference used to rank the similarity against each text in `texts`.
-> * **Sequence Classification**: classic sequence classification models expose the endpoint `/predict` which expects a payload with the key `inputs` which is either a string or a list of strings to classify.
-> More information at <https://huggingface.co/docs/text-embeddings-inference/quick_tour>.
+> - **Text Embeddings**: text embedding models expose the endpoint `/embed` expecting a payload with the key `inputs` which is either a string or a list of strings to be embedded.
+> - **Re-rank**: re-ranker models expose the endpoint `/rerank` expecting a payload with the keys `query` and `texts`, where the `query` is the reference used to rank the similarity against each text in `texts`.
+> - **Sequence Classification**: classic sequence classification models expose the endpoint `/predict` which expects a payload with the key `inputs` which is either a string or a list of strings to classify.
+>   More information at <https://huggingface.co/docs/text-embeddings-inference/quick_tour>.
 
 ### Via cURL
 

--- a/examples/gke/tei-from-gcs-deployment/README.md
+++ b/examples/gke/tei-from-gcs-deployment/README.md
@@ -6,8 +6,8 @@ BGE, standing for BAAI General Embedding, is a collection of embedding models re
 
 First, you need to install both `gcloud` and `kubectl` in your local machine, which are the command-line tools for Google Cloud and Kubernetes, respectively, to interact with the GCP and the GKE Cluster.
 
-* To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
-* To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
+- To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
+- To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 Optionally, to ease the usage of the commands within this tutorial, you need to set the following environment variables for GCP:
 
@@ -42,7 +42,7 @@ gcloud components install gke-gcloud-auth-plugin
 
 > [!NOTE]
 > Installing the `gke-gcloud-auth-plugin` does not need to be installed via `gcloud` specifically, to read more about the alternative installation methods, please visit <https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin>.
->
+
 ## Create GKE Cluster
 
 Once everything is set up, you can proceed with the creation of the GKE Cluster and the node pool, which in this case will be a single CPU node as for most of the workloads CPU inference is enough to serve most of the text embeddings models, while it could benefit a lot from GPU serving.
@@ -144,10 +144,10 @@ Now you can proceed to the Kubernetes deployment of the Hugging Face DLC for TEI
 
 The Hugging Face DLC for TEI will be deployed via `kubectl`, from the configuration files in either the `cpu-config/` or the `gpu-config/` directories depending on whether you want to use the CPU or GPU accelerators, respectively:
 
-* `deployment.yaml`: contains the deployment details of the pod including the reference to the Hugging Face DLC for TEI setting the `MODEL_ID` to the model path in the volume mount, in this case `/data/bge-base-en-v1.5`.
-* `service.yaml`: contains the service details of the pod, exposing the port 80 for the TEI service.
-* `storageclass.yaml`: contains the storage class details of the pod, defining the storage class for the volume mount.
-* (optional) `ingress.yaml`: contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
+- `deployment.yaml`: contains the deployment details of the pod including the reference to the Hugging Face DLC for TEI setting the `MODEL_ID` to the model path in the volume mount, in this case `/data/bge-base-en-v1.5`.
+- `service.yaml`: contains the service details of the pod, exposing the port 80 for the TEI service.
+- `storageclass.yaml`: contains the storage class details of the pod, defining the storage class for the volume mount.
+- (optional) `ingress.yaml`: contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
 kubectl apply -f cpu-config/
@@ -175,25 +175,25 @@ kubectl apply -f cpu-config/
 
 To run the inference over the deployed TEI service, you can either:
 
-* Port-forwarding the deployed TEI service to the port 8080, so as to access via `localhost` with the command:
+- Port-forwarding the deployed TEI service to the port 8080, so as to access via `localhost` with the command:
 
-    ```bash
-    kubectl port-forward --namespace $NAMESPACE service/tei-service 8080:8080
-    ```
+  ```bash
+  kubectl port-forward --namespace $NAMESPACE service/tei-service 8080:8080
+  ```
 
-* Accessing the TEI service via the external IP of the ingress, which is the default scenario here since you have defined the ingress configuration in either the `cpu-configs/ingress.yaml` or the `gpu-config/ingress.yaml` file (but it can be skipped in favour of the port-forwarding), that can be retrieved with the following command:
+- Accessing the TEI service via the external IP of the ingress, which is the default scenario here since you have defined the ingress configuration in either the `cpu-configs/ingress.yaml` or the `gpu-config/ingress.yaml` file (but it can be skipped in favour of the port-forwarding), that can be retrieved with the following command:
 
-    ```bash
-    kubectl get ingress --namespace $NAMESPACE tei-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    ```
+  ```bash
+  kubectl get ingress --namespace $NAMESPACE tei-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+  ```
 
 > [!NOTE]
 > TEI exposes different inference endpoints based on the task that the model is serving:
 >
-> * **Text Embeddings**: text embedding models expose the endpoint `/embed` expecting a payload with the key `inputs` which is either a string or a list of strings to be embedded.
-> * **Re-rank**: re-ranker models expose the endpoint `/rerank` expecting a payload with the keys `query` and `texts`, where the `query` is the reference used to rank the similarity against each text in `texts`.
-> * **Sequence Classification**: classic sequence classification models expose the endpoint `/predict` which expects a payload with the key `inputs` which is either a string or a list of strings to classify.
-> More information at <https://huggingface.co/docs/text-embeddings-inference/quick_tour>.
+> - **Text Embeddings**: text embedding models expose the endpoint `/embed` expecting a payload with the key `inputs` which is either a string or a list of strings to be embedded.
+> - **Re-rank**: re-ranker models expose the endpoint `/rerank` expecting a payload with the keys `query` and `texts`, where the `query` is the reference used to rank the similarity against each text in `texts`.
+> - **Sequence Classification**: classic sequence classification models expose the endpoint `/predict` which expects a payload with the key `inputs` which is either a string or a list of strings to classify.
+>   More information at <https://huggingface.co/docs/text-embeddings-inference/quick_tour>.
 
 ### Via cURL
 

--- a/examples/gke/tei-from-gcs-deployment/README.md
+++ b/examples/gke/tei-from-gcs-deployment/README.md
@@ -22,6 +22,7 @@ Then you need to login into your GCP account and set the project ID to the one y
 
 ```bash
 gcloud auth login
+gcloud auth application-default login  # For local development
 gcloud config set project $PROJECT_ID
 ```
 

--- a/examples/gke/tgi-deployment/README.md
+++ b/examples/gke/tgi-deployment/README.md
@@ -21,6 +21,7 @@ Then you need to login into your GCP account and set the project ID to the one y
 
 ```bash
 gcloud auth login
+gcloud auth application-default login  # For local development
 gcloud config set project $PROJECT_ID
 ```
 

--- a/examples/gke/tgi-deployment/README.md
+++ b/examples/gke/tgi-deployment/README.md
@@ -6,8 +6,8 @@ Meta Llama 3 is the latest LLM from the Llama family, released by Meta; coming i
 
 First, you need to install both `gcloud` and `kubectl` in your local machine, which are the command-line tools for Google Cloud and Kubernetes, respectively, to interact with the GCP and the GKE Cluster.
 
-* To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
-* To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
+- To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
+- To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 Optionally, to ease the usage of the commands within this tutorial, you need to set the following environment variables for GCP:
 
@@ -125,10 +125,10 @@ Now you can proceed to the Kubernetes deployment of the Hugging Face DLC for TGI
 
 The Hugging Face DLC for TGI will be deployed via `kubectl`, from the configuration files in the `config/` directory:
 
-* `deployment.yaml`: contains the deployment details of the pod including the reference to the Hugging Face DLC for TGI setting the `MODEL_ID` to [`meta-llama/Meta-Llama-3.1-8B-Instruct`](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct).
+- `deployment.yaml`: contains the deployment details of the pod including the reference to the Hugging Face DLC for TGI setting the `MODEL_ID` to [`meta-llama/Meta-Llama-3.1-8B-Instruct`](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct).
 
-* `service.yaml`: contains the service details of the pod, exposing the port 80 for the TGI service.
-* (optional) `ingress.yaml`: contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
+- `service.yaml`: contains the service details of the pod, exposing the port 80 for the TGI service.
+- (optional) `ingress.yaml`: contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
 kubectl apply -f config/
@@ -153,17 +153,17 @@ kubectl apply -f config/
 
 To run the inference over the deployed TGI service, you can either:
 
-* Port-forwarding the deployed TGI service to the port 8080, so as to access via `localhost` with the command:
+- Port-forwarding the deployed TGI service to the port 8080, so as to access via `localhost` with the command:
 
-    ```bash
-    kubectl port-forward service/tgi-service 8080:8080
-    ```
+  ```bash
+  kubectl port-forward service/tgi-service 8080:8080
+  ```
 
-* Accessing the TGI service via the external IP of the ingress, which is the default scenario here since you have defined the ingress configuration in the `config/ingress.yaml` file (but it can be skipped in favour of the port-forwarding), that can be retrieved with the following command:
+- Accessing the TGI service via the external IP of the ingress, which is the default scenario here since you have defined the ingress configuration in the `config/ingress.yaml` file (but it can be skipped in favour of the port-forwarding), that can be retrieved with the following command:
 
-    ```bash
-    kubectl get ingress tgi-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    ```
+  ```bash
+  kubectl get ingress tgi-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+  ```
 
 ### Via cURL
 

--- a/examples/gke/tgi-from-gcs-deployment/README.md
+++ b/examples/gke/tgi-from-gcs-deployment/README.md
@@ -22,6 +22,7 @@ Then you need to login into your GCP account and set the project ID to the one y
 
 ```bash
 gcloud auth login
+gcloud auth application-default login  # For local development
 gcloud config set project $PROJECT_ID
 ```
 

--- a/examples/gke/trl-full-fine-tuning/README.md
+++ b/examples/gke/trl-full-fine-tuning/README.md
@@ -6,8 +6,8 @@ Gemma is a family of lightweight, state-of-the-art open models built from the sa
 
 First, you need to install both `gcloud` and `kubectl` in your local machine, which are the command-line tools for Google Cloud and Kubernetes, respectively, to interact with the GCP and the GKE Cluster.
 
-* To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
-* To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
+- To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
+- To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 Optionally, to ease the usage of the commands within this tutorial, you need to set the following environment variables for GCP:
 

--- a/examples/gke/trl-full-fine-tuning/README.md
+++ b/examples/gke/trl-full-fine-tuning/README.md
@@ -21,6 +21,7 @@ Then you need to login into your GCP account and set the project ID to the one y
 
 ```bash
 gcloud auth login
+gcloud auth application-default login  # For local development
 gcloud config set project $PROJECT_ID
 ```
 

--- a/examples/gke/trl-lora-fine-tuning/README.md
+++ b/examples/gke/trl-lora-fine-tuning/README.md
@@ -21,6 +21,7 @@ Then you need to login into your GCP account and set the project ID to the one y
 
 ```bash
 gcloud auth login
+gcloud auth application-default login  # For local development
 gcloud config set project $PROJECT_ID
 ```
 

--- a/examples/gke/trl-lora-fine-tuning/README.md
+++ b/examples/gke/trl-lora-fine-tuning/README.md
@@ -6,8 +6,8 @@ Mistral is a family of models with varying sizes, created by the Mistral AI team
 
 First, you need to install both `gcloud` and `kubectl` in your local machine, which are the command-line tools for Google Cloud and Kubernetes, respectively, to interact with the GCP and the GKE Cluster.
 
-* To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
-* To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
+- To install `gcloud`, follow the instructions at [Cloud SDK Documentation - Install the gcloud CLI](https://cloud.google.com/sdk/docs/install).
+- To install `kubectl`, follow the instructions at [Kubernetes Documentation - Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 Optionally, to ease the usage of the commands within this tutorial, you need to set the following environment variables for GCP:
 

--- a/examples/vertex-ai/README.md
+++ b/examples/vertex-ai/README.md
@@ -8,19 +8,19 @@ For Google Vertex AI, we differentiate between the executable Jupyter Notebook e
 
 ### Training Examples
 
-| Example | Description
-|---------|-------------
-| [trl-full-sft-fine-tuning-on-vertex-ai](./notebooks/trl-full-sft-fine-tuning-on-vertex-ai) | Full SFT fine-tuning of Mistral 7B v0.3 in a multi-GPU instance with TRL on Vertex AI.
-| [trl-lora-sft-fine-tuning-on-vertex-ai](./notebooks/trl-lora-sft-fine-tuning-on-vertex-ai) | LoRA SFT fine-tuning of Mistral 7B v0.3 in a single GPU instance with TRL on Vertex AI.
+| Example                                                                                    | Description                                                                             |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [trl-full-sft-fine-tuning-on-vertex-ai](./notebooks/trl-full-sft-fine-tuning-on-vertex-ai) | Full SFT fine-tuning of Mistral 7B v0.3 in a multi-GPU instance with TRL on Vertex AI.  |
+| [trl-lora-sft-fine-tuning-on-vertex-ai](./notebooks/trl-lora-sft-fine-tuning-on-vertex-ai) | LoRA SFT fine-tuning of Mistral 7B v0.3 in a single GPU instance with TRL on Vertex AI. |
 
 ### Inference Examples
 
-| Example | Description
-|---------|-------------
-| [deploy-bert-on-vertex-ai](./notebooks/deploy-bert-on-vertex-ai) | Deploying a BERT model for a text classification task using `huggingface-inference-toolkit` for a Custom Prediction Routine (CPR) on Vertex AI.
-| [deploy-embedding-on-vertex-ai](./notebooks/deploy-embedding-on-vertex-ai) | Deploying an embedding model with Text Embeddings Inference (TEI) on Vertex AI.
-| [deploy-gemma-on-vertex-ai](./notebooks/deploy-gemma-on-vertex-ai) | Deploying Gemma 7B Instruct with Text Generation Inference (TGI) on Vertex AI.
-| [deploy-gemma-from-gcs-on-vertex-ai](./notebooks/deploy-gemma-from-gcs-on-vertex-ai) | Deploying Gemma 7B Instruct with Text Generation Inference (TGI) from a GCS Bucket on Vertex AI.
+| Example                                                                              | Description                                                                                                                                     |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| [deploy-bert-on-vertex-ai](./notebooks/deploy-bert-on-vertex-ai)                     | Deploying a BERT model for a text classification task using `huggingface-inference-toolkit` for a Custom Prediction Routine (CPR) on Vertex AI. |
+| [deploy-embedding-on-vertex-ai](./notebooks/deploy-embedding-on-vertex-ai)           | Deploying an embedding model with Text Embeddings Inference (TEI) on Vertex AI.                                                                 |
+| [deploy-gemma-on-vertex-ai](./notebooks/deploy-gemma-on-vertex-ai)                   | Deploying Gemma 7B Instruct with Text Generation Inference (TGI) on Vertex AI.                                                                  |
+| [deploy-gemma-from-gcs-on-vertex-ai](./notebooks/deploy-gemma-from-gcs-on-vertex-ai) | Deploying Gemma 7B Instruct with Text Generation Inference (TGI) from a GCS Bucket on Vertex AI.                                                |
 
 ## Pipelines
 

--- a/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
@@ -83,6 +83,7 @@
    "outputs": [],
    "source": [
     "!gcloud auth login\n",
+    "!gcloud auth application-default login  # For local development\n",
     "!gcloud config set project $PROJECT_ID"
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
@@ -288,7 +288,7 @@
    "outputs": [],
    "source": [
     "output = deployed_model.predict(instances=[\"I love this product\", \"I hate this product\"], parameters={\"top_k\": 2})\n",
-    "output.predictions"
+    "print(output.predictions)"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
@@ -288,7 +288,7 @@
    "outputs": [],
    "source": [
     "output = deployed_model.predict(instances=[\"I love this product\", \"I hate this product\"], parameters={\"top_k\": 2})\n",
-    "print(output.predictions)"
+    "print(output.predictions[0])"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
@@ -286,7 +286,7 @@
    "outputs": [],
    "source": [
     "output = deployed_model.predict(instances=[{\"inputs\": \"What is Deep Learning?\"}])\n",
-    "output.predictions[0][0][:5], len(output.predictions[0][0])"
+    "print(output.predictions)"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
@@ -286,7 +286,7 @@
    "outputs": [],
    "source": [
     "output = deployed_model.predict(instances=[{\"inputs\": \"What is Deep Learning?\"}])\n",
-    "print(output.predictions)"
+    "print(output.predictions[0][0][:5], len(output.predictions[0][0])"
    ]
   },
   {
@@ -296,7 +296,7 @@
     "Which produces the following output (truncated for brevity, but original tensor length is 1024, which is the embedding dimension of [`BAAI/bge-large-en-v1.5`](https://huggingface.co/BAAI/bge-large-en-v1.5)):\n",
     "\n",
     "```\n",
-    "[[0.018108826, 0.0029993146, -0.04984767, -0.035081815, 0.014210845, ...]]\n",
+    "([0.018108826, 0.0029993146, -0.04984767, -0.035081815, 0.014210845], 1024)\n",
     "```"
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
@@ -83,6 +83,7 @@
    "outputs": [],
    "source": [
     "!gcloud auth login\n",
+    "!gcloud auth application-default login  # For local development\n",
     "!gcloud config set project $PROJECT_ID"
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-gemma-from-gcs-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-gemma-from-gcs-on-vertex-ai/vertex-notebook.ipynb
@@ -554,7 +554,8 @@
     "            },\n",
     "        },\n",
     "    ]\n",
-    ")"
+    ")\n",
+    "print(output.predictions)"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-gemma-from-gcs-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-gemma-from-gcs-on-vertex-ai/vertex-notebook.ipynb
@@ -85,6 +85,7 @@
    "outputs": [],
    "source": [
     "!gcloud auth login\n",
+    "!gcloud auth application-default login  # For local development\n",
     "!gcloud config set project $PROJECT_ID"
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-gemma-from-gcs-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-gemma-from-gcs-on-vertex-ai/vertex-notebook.ipynb
@@ -555,7 +555,7 @@
     "        },\n",
     "    ]\n",
     ")\n",
-    "print(output.predictions)"
+    "print(output.predictions[0])"
    ]
   },
   {
@@ -580,7 +580,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the Vertex AI Endpoint was deployed in a different session and you want to use it but don't have access to the `deployed_model` variable returned by the `aiplatform.Model.deploy` method as in the previous section; you can also run the following snippet to instantiate the deployed `aiplatform.Endpoint` via its resource name as `projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/{ENDPOINT_ID}`."
+    "If the Vertex AI Endpoint was deployed in a different session and you want to use it but don't have access to the `deployed_model` variable returned by the `aiplatform.Model.deploy` method as in the previous section; you can also run the following snippet to instantiate the deployed `aiplatform.Endpoint` via its resource name as `projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/{ENDPOINT_ID}`.\n",
+    "\n",
+    "> Note that you will need to either retrieve the resource name i.e. the `projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/{ENDPOINT_ID}` URL youself via the Google Cloud Console, or just replace the `ENDPOINT_ID` below that can either be found via the previously instantiated `endpoint` as `endpoint.id` or via the Google Cloud Console under the Online predictions where the endpoint is listed."
    ]
   },
   {
@@ -593,6 +595,19 @@
     "from google.cloud import aiplatform\n",
     "\n",
     "aiplatform.init(project=os.getenv(\"PROJECT_ID\"), location=os.getenv(\"LOCATION\"))\n",
+    "\n",
+    "endpoint_display_name = \"google--gemma-7b-it-endpoint\"  # TODO: change to your endpoint display name\n",
+    "\n",
+    "# Iterates over all the Vertex AI Endpoints within the current project and keeps the first match (if any), otherwise set to None\n",
+    "ENDPOINT_ID = next(\n",
+    "    (endpoint.name for endpoint in aiplatform.Endpoint.list() \n",
+    "     if endpoint.display_name == endpoint_display_name), \n",
+    "    None\n",
+    ")\n",
+    "assert ENDPOINT_ID, (\n",
+    "    \"`ENDPOINT_ID` is not set, please make sure that the `endpoint_display_name` is correct at \"\\\n",
+    "    f\"https://console.cloud.google.com/vertex-ai/online-prediction/endpoints?project={os.getenv('PROJECT_ID')}\"\n",
+    ")\n",
     "\n",
     "endpoint = aiplatform.Endpoint(f\"projects/{os.getenv('PROJECT_ID')}/locations/{os.getenv('LOCATION')}/endpoints/{ENDPOINT_ID}\")\n",
     "output = endpoint.predict(\n",
@@ -607,7 +622,8 @@
     "            },\n",
     "        },\n",
     "    ],\n",
-    ")"
+    ")\n",
+    "print(output.predictions[0])"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
@@ -402,7 +402,8 @@
     "            },\n",
     "        },\n",
     "    ]\n",
-    ")"
+    ")\n",
+    "print(output.predictions)"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
@@ -403,7 +403,7 @@
     "        },\n",
     "    ]\n",
     ")\n",
-    "print(output.predictions)"
+    "print(output.predictions[0])"
    ]
   },
   {
@@ -478,7 +478,7 @@
     "        },\n",
     "    ],\n",
     ")\n",
-    "print(output.predictions)"
+    "print(output.predictions[0])"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
@@ -435,7 +435,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the Vertex AI Endpoint was deployed in a different session and you want to use it but don't have access to the `deployed_model` variable returned by the `aiplatform.Model.deploy` method as in the previous section; you can also run the following snippet to instantiate the deployed `aiplatform.Endpoint` via its resource name as `projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/{ENDPOINT_ID}`."
+    "If the Vertex AI Endpoint was deployed in a different session and you want to use it but don't have access to the `deployed_model` variable returned by the `aiplatform.Model.deploy` method as in the previous section; you can also run the following snippet to instantiate the deployed `aiplatform.Endpoint` via its resource name as `projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/{ENDPOINT_ID}`.\n",
+    "\n",
+    "> Note that you will need to either retrieve the resource name i.e. the `projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/{ENDPOINT_ID}` URL youself via the Google Cloud Console, or just replace the `ENDPOINT_ID` below that can either be found via the previously instantiated `endpoint` as `endpoint.id` or via the Google Cloud Console under the Online predictions where the endpoint is listed."
    ]
   },
   {
@@ -448,6 +450,19 @@
     "from google.cloud import aiplatform\n",
     "\n",
     "aiplatform.init(project=os.getenv(\"PROJECT_ID\"), location=os.getenv(\"LOCATION\"))\n",
+    "\n",
+    "endpoint_display_name = \"google--gemma-7b-it-endpoint\"  # TODO: change to your endpoint display name\n",
+    "\n",
+    "# Iterates over all the Vertex AI Endpoints within the current project and keeps the first match (if any), otherwise set to None\n",
+    "ENDPOINT_ID = next(\n",
+    "    (endpoint.name for endpoint in aiplatform.Endpoint.list() \n",
+    "     if endpoint.display_name == endpoint_display_name), \n",
+    "    None\n",
+    ")\n",
+    "assert ENDPOINT_ID, (\n",
+    "    \"`ENDPOINT_ID` is not set, please make sure that the `endpoint_display_name` is correct at \"\\\n",
+    "    f\"https://console.cloud.google.com/vertex-ai/online-prediction/endpoints?project={os.getenv('PROJECT_ID')}\"\n",
+    ")\n",
     "\n",
     "endpoint = aiplatform.Endpoint(f\"projects/{os.getenv('PROJECT_ID')}/locations/{os.getenv('LOCATION')}/endpoints/{ENDPOINT_ID}\")\n",
     "output = endpoint.predict(\n",
@@ -462,7 +477,8 @@
     "            },\n",
     "        },\n",
     "    ],\n",
-    ")"
+    ")\n",
+    "print(output.predictions)"
    ]
   },
   {

--- a/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-gemma-on-vertex-ai/vertex-notebook.ipynb
@@ -83,6 +83,7 @@
    "outputs": [],
    "source": [
     "!gcloud auth login\n",
+    "!gcloud auth application-default login  # For local development\n",
     "!gcloud config set project $PROJECT_ID"
    ]
   },

--- a/examples/vertex-ai/notebooks/trl-full-sft-fine-tuning-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/trl-full-sft-fine-tuning-on-vertex-ai/vertex-notebook.ipynb
@@ -77,6 +77,7 @@
    "outputs": [],
    "source": [
     "!gcloud auth login\n",
+    "!gcloud auth application-default login  # For local development\n",
     "!gcloud config set project $PROJECT_ID"
    ]
   },

--- a/examples/vertex-ai/notebooks/trl-lora-sft-fine-tuning-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/trl-lora-sft-fine-tuning-on-vertex-ai/vertex-notebook.ipynb
@@ -77,6 +77,7 @@
    "outputs": [],
    "source": [
     "!gcloud auth login\n",
+    "!gcloud auth application-default login  # For local development\n",
     "!gcloud config set project $PROJECT_ID"
    ]
   },


### PR DESCRIPTION
## Description

This PR adds the missing `gcloud auth application-default login` command to both the Google Kubernetes Engine (GKE) and Vertex AI examples, so as to ensure that when running the examples locally via a Google Cloud account the credentials are there. Otherwise an authentication error will be raised stating that the default credentials were not found.

This PR also updates and aligns the formatting of the existing `README.md` files; and applies minor fixes and improvements to some of the `vertex-notebook.ipynb` files.

Kudos to @philschmid for the fixes and improvements!