### PR TITLE
Disable insecure `kubelet` read-only 10255 port

### DIFF
--- a/examples/gke/tei-deployment/README.md
+++ b/examples/gke/tei-deployment/README.md
@@ -61,7 +61,8 @@ gcloud container clusters create-auto $CLUSTER_NAME \
     --project=$PROJECT_ID \
     --location=$LOCATION \
     --release-channel=stable \
-    --cluster-version=1.28
+    --cluster-version=1.28 \
+    --no-autoprovisioning-enable-insecure-kubelet-readonly-port
 ```
 
 > [!NOTE]

--- a/examples/gke/tei-from-gcs-deployment/README.md
+++ b/examples/gke/tei-from-gcs-deployment/README.md
@@ -62,7 +62,8 @@ gcloud container clusters create-auto $CLUSTER_NAME \
     --project=$PROJECT_ID \
     --location=$LOCATION \
     --release-channel=stable \
-    --cluster-version=1.28
+    --cluster-version=1.28 \
+    --no-autoprovisioning-enable-insecure-kubelet-readonly-port
 ```
 
 > [!NOTE]

--- a/examples/gke/tgi-deployment/README.md
+++ b/examples/gke/tgi-deployment/README.md
@@ -56,7 +56,8 @@ gcloud container clusters create-auto $CLUSTER_NAME \
     --project=$PROJECT_ID \
     --location=$LOCATION \
     --release-channel=stable \
-    --cluster-version=1.28
+    --cluster-version=1.28 \
+    --no-autoprovisioning-enable-insecure-kubelet-readonly-port
 ```
 
 > [!NOTE]

--- a/examples/gke/tgi-from-gcs-deployment/README.md
+++ b/examples/gke/tgi-from-gcs-deployment/README.md
@@ -57,7 +57,8 @@ gcloud container clusters create-auto $CLUSTER_NAME \
     --project=$PROJECT_ID \
     --location=$LOCATION \
     --release-channel=stable \
-    --cluster-version=1.28
+    --cluster-version=1.28 \
+    --no-autoprovisioning-enable-insecure-kubelet-readonly-port
 ```
 
 > [!NOTE]

--- a/examples/gke/trl-full-fine-tuning/README.md
+++ b/examples/gke/trl-full-fine-tuning/README.md
@@ -56,7 +56,8 @@ gcloud container clusters create-auto $CLUSTER_NAME \
     --project=$PROJECT_ID \
     --location=$LOCATION \
     --release-channel=stable \
-    --cluster-version=1.28
+    --cluster-version=1.28 \
+    --no-autoprovisioning-enable-insecure-kubelet-readonly-port
 ```
 
 > [!NOTE]

--- a/examples/gke/trl-lora-fine-tuning/README.md
+++ b/examples/gke/trl-lora-fine-tuning/README.md
@@ -56,7 +56,8 @@ gcloud container clusters create-auto $CLUSTER_NAME \
     --project=$PROJECT_ID \
     --location=$LOCATION \
     --release-channel=stable \
-    --cluster-version=1.28
+    --cluster-version=1.28 \
+    --no-autoprovisioning-enable-insecure-kubelet-readonly-port
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Description

This PR sets the flag `--no-autoprovisioning-enable-insecure-kubelet-readonly-port` within the `gcloud container clusters create-auto` command, so that the `kubelet` read-only port 10255 is not exposed as it's not considered secure.

More information in the [Google Kubernetes Engine (GKE) Documentation - Disable the kubelet read-only port in GKE clusters](https://cloud.google.com/kubernetes-engine/docs/how-to/disable-kubelet-readonly-port).

Closes #94 