### PR TITLE
small updates to the TGI Cloud Run readme

### DIFF
--- a/examples/cloud-run/tgi-deployment/README.md
+++ b/examples/cloud-run/tgi-deployment/README.md
@@ -50,7 +50,7 @@ The `gcloud beta run deploy` command needs you to specify the following paramete
   - `--model-id`: The model ID to use, in this case, [`hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4`](https://huggingface.co/hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4).
   - `--quantize`: The quantization method to use, in this case, `awq`. If not specified, it will be retrieved from the `quantization_config->quant_method` in the `config.json` file.
 - `--port`: The port the container listens to.
-- `--cpu` and `--memory`: The number of CPUs and amount of memory to allocate to the container. Needs to be set to 4 and 16Gi (16 GiB), respectively; as that's a requirement for using the GPU.
+- `--cpu` and `--memory`: The number of CPUs and amount of memory to allocate to the container. Needs to be set to 4 and 16Gi (16 GiB), respectively; as that's the minimum requirement for using the GPU.
 - `--no-cpu-throttling`: Disables CPU throttling, which is required for using the GPU.
 - `--gpu` and `--gpu-type`: The number of GPUs and the GPU type to use. Needs to be set to 1 and `nvidia-l4`, respectively; as at the time of writing this tutorial, those are the only available options as Cloud Run on GPUs is still under preview.
 - `--max-instances`: The maximum number of instances to run, set to 3, but default maximum value is 7. Alternatively, one could set it to 1 too, but that could eventually lead to downtime during infrastructure migrations, so anything above 1 is recommended.
@@ -63,8 +63,8 @@ gcloud beta run deploy $SERVICE_NAME \
     --image=$CONTAINER_URI \
     --args="--model-id=hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4,--quantize=awq,--max-concurrent-requests=64" \
     --port=8080 \
-    --cpu=8 \
-    --memory=32Gi \
+    --cpu=4 \
+    --memory=16Gi \
     --no-cpu-throttling \
     --gpu=1 \
     --gpu-type=nvidia-l4 \

--- a/examples/cloud-run/tgi-deployment/README.md
+++ b/examples/cloud-run/tgi-deployment/README.md
@@ -255,7 +255,7 @@ To send a POST request to the TGI service using `cURL`, you can run the followin
 ```bash
 curl $SERVICE_URL/v1/chat/completions \
     -X POST \
-    -H 'Authorization: Bearer $ACCESS_TOKEN' \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
         "model": "tgi",


### PR DESCRIPTION
A couple of additional suggestions:

1. when using cloud workstations or cloud shell, the (bash) terminal doesn't get the contents of the $ACCESS_TOKEN before sending the cURL request. The result is always `Your client does not have permission to the requested URL <code>/v1/chat/completions</code>.` which might be difficult to debug since the Access Token is valid. I believe using double-quotes here works fine for other shells.
2. The minimum requirements for GPUs is 4 CPU and 16 memory. I've updated the gcloud command and clarified the description to call out how this is the minimum requirement.