### PR TITLE
Revert `ingressClassName` over `annotation`

### DIFF
--- a/examples/gke/tei-deployment/cpu-config/ingress.yaml
+++ b/examples/gke/tei-deployment/cpu-config/ingress.yaml
@@ -2,8 +2,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tei-ingress
+  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
 spec:
-  ingressClassName: "gce"
   rules:
     - http:
         paths:

--- a/examples/gke/tei-deployment/gpu-config/ingress.yaml
+++ b/examples/gke/tei-deployment/gpu-config/ingress.yaml
@@ -2,8 +2,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tei-ingress
+  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
 spec:
-  ingressClassName: "gce"
   rules:
     - http:
         paths:

--- a/examples/gke/tei-from-gcs-deployment/cpu-config/ingress.yaml
+++ b/examples/gke/tei-from-gcs-deployment/cpu-config/ingress.yaml
@@ -3,8 +3,10 @@ kind: Ingress
 metadata:
   name: tei-ingress
   namespace: hf-gke-namespace
+  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
 spec:
-  ingressClassName: "gce"
   rules:
     - http:
         paths:

--- a/examples/gke/tei-from-gcs-deployment/gpu-config/ingress.yaml
+++ b/examples/gke/tei-from-gcs-deployment/gpu-config/ingress.yaml
@@ -3,8 +3,10 @@ kind: Ingress
 metadata:
   name: tei-ingress
   namespace: hf-gke-namespace
+  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
 spec:
-  ingressClassName: "gce"
   rules:
     - http:
         paths:

--- a/examples/gke/tgi-deployment/config/ingress.yaml
+++ b/examples/gke/tgi-deployment/config/ingress.yaml
@@ -2,8 +2,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tgi-ingress
+  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
 spec:
-  ingressClassName: "gce"
   rules:
     - http:
         paths:

--- a/examples/gke/tgi-from-gcs-deployment/config/ingress.yaml
+++ b/examples/gke/tgi-from-gcs-deployment/config/ingress.yaml
@@ -3,8 +3,10 @@ kind: Ingress
 metadata:
   name: tgi-ingress
   namespace: hf-gke-namespace
+  # https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
 spec:
-  ingressClassName: "gce"
   rules:
     - http:
         paths:


### PR DESCRIPTION
## Description

This PR reverts the PR #107, since even though it's deprecated in Kubernetes; it needs to be specified via the `annotations` for it to work on Google Kubernetes Engine (GKE).

Now a note has been included so that the `DeprecationWarning` is ignored.

More information at
https://cloud.google.com/kubernetes-engine/docs/concepts/ingress