### PR TITLE
Add reference to GitHub in documentation examples

### DIFF
--- a/docs/scripts/auto-generate-examples.py
+++ b/docs/scripts/auto-generate-examples.py
@@ -101,7 +101,7 @@ def process_file(root, file, dir):
         example_url += "/vertex-notebook.ipynb"
 
     # Add the final note
-    content += f"\n\n---\n\n<Tip>\n\n📍 Find the complete example on GitHub [here]({example_url})!\n\n</Tip>"
+    content += f"\n---\n<Tip>\n\n📍 Find the complete example on GitHub [here]({example_url})!\n\n</Tip>"
 
     with open(target, "w") as f:
         f.write(content)

--- a/docs/scripts/auto-generate-examples.py
+++ b/docs/scripts/auto-generate-examples.py
@@ -93,6 +93,14 @@ def process_file(root, file, dir):
     else:
         print("No relative paths found in the processed file.")
 
+    # Calculate the example URL
+    example_url = (
+        f"https://github.com/huggingface/Google-Cloud-Containers/tree/main/{root}"
+    )
+
+    # Add the final note
+    content += f"\n\n📍 Find the complete example on GitHub [here]({example_url})!"
+
     with open(target, "w") as f:
         f.write(content)
 

--- a/docs/scripts/auto-generate-examples.py
+++ b/docs/scripts/auto-generate-examples.py
@@ -97,9 +97,11 @@ def process_file(root, file, dir):
     example_url = (
         f"https://github.com/huggingface/Google-Cloud-Containers/tree/main/{root}"
     )
+    if file.__contains__("ipynb"):
+        example_url += "/vertex-notebook.ipynb"
 
     # Add the final note
-    content += f"\n\n<Tip important>\n\n📍 Find the complete example on GitHub [here]({example_url})!\n\n</Tip>"
+    content += f"\n\n---\n\n<Tip>\n\n📍 Find the complete example on GitHub [here]({example_url})!\n\n</Tip>"
 
     with open(target, "w") as f:
         f.write(content)

--- a/docs/scripts/auto-generate-examples.py
+++ b/docs/scripts/auto-generate-examples.py
@@ -99,7 +99,7 @@ def process_file(root, file, dir):
     )
 
     # Add the final note
-    content += f"\n\n📍 Find the complete example on GitHub [here]({example_url})!"
+    content += f"\n\n<Tip important>\n\n📍 Find the complete example on GitHub [here]({example_url})!\n\n</Tip>"
 
     with open(target, "w") as f:
         f.write(content)

--- a/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-bert-on-vertex-ai/vertex-notebook.ipynb
@@ -262,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!WARN]\n",
+    "> [!WARNING]\n",
     "> The Vertex AI endpoint deployment via the `deploy` method may take from 15 to 25 minutes."
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-embedding-on-vertex-ai/vertex-notebook.ipynb
@@ -260,7 +260,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!WARN]\n",
+    "> [!WARNING]\n",
     "> The Vertex AI endpoint deployment via the `deploy` method may take from 15 to 25 minutes."
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-flux-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-flux-on-vertex-ai/vertex-notebook.ipynb
@@ -296,7 +296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!WARN]\n",
+    "> [!WARNING]\n",
     "> The Vertex AI endpoint deployment via the `deploy` method may take from 15 to 25 minutes."
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-llama-3-1-405b-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-llama-3-1-405b-on-vertex-ai/vertex-notebook.ipynb
@@ -348,7 +348,7 @@
    "id": "18dd3890-eeb1-42a5-86f1-471c06194147",
    "metadata": {},
    "source": [
-    "> [!WARN]\n",
+    "> [!WARNING]\n",
     "> [`meta-llama/Meta-Llama-3.1-405B-Instruct-FP8`](https://huggingface.co/meta-llama/Meta-Llama-3.1-405B-Instruct-FP8) deployment on Vertex AI will take \\~30 minutes to deploy, as it needs to allocate the resources on Google Cloud, and then download the weights from the Hugging Face Hub (\\~10 minutes) and load those for inference in TGI (\\~3 minutes)."
    ]
   },

--- a/examples/vertex-ai/notebooks/deploy-llama-vision-on-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/deploy-llama-vision-on-vertex-ai/vertex-notebook.ipynb
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!WARN]\n",
+    "> [!WARNING]\n",
     "> Note that the `MESSAGES_API_ENABLED` flag will only work from the TGI 2.3 DLC i.e. `us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311`, onwards.\n",
     ">\n",
     "> For the previous releases the `MESSAGES_API_ENABLED` flag won't work as it was introduced [in the following TGI PR](https://github.com/huggingface/text-generation-inference/pull/2481), the uncompatible releases being:\n",

--- a/examples/vertex-ai/notebooks/evaluate-llms-with-vertex-ai/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/evaluate-llms-with-vertex-ai/vertex-notebook.ipynb
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!WARN]\n",
+    "> [!WARNING]\n",
     "> The Vertex AI endpoint deployment via the `deploy` method may take from 15 to 25 minutes.\n",
     "\n",
     "After the model is deployed, we can test our endpoint. We generate a helper `generate` function to send requests to the deployed model. This will be later used to send requests to the deployed model and collect the outputs for evaluation."


### PR DESCRIPTION
## Description

This PR adds a note at the end of all the auto-generated examples, so that those come with a GitHub reference to the actual example files in this repository.

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/3e006861-907b-4bc8-9873-b87eda351e38">

Additionally, some `WARNING` messages have been fixed since those were using the notation `> [!WARN]` which is wrong, and those have been updated to `> [!WARNING]` which is the correct down for Markdown rendering and the one we're converting into HuggingFace-formatting as `<Tip warning>`.
