### PR TITLE
Add missing `git clone` command in `examples/gke/*`

### DIFF
--- a/examples/gke/tei-deployment/README.md
+++ b/examples/gke/tei-deployment/README.md
@@ -105,11 +105,12 @@ The Hugging Face DLC for TEI will be deployed via `kubectl`, from the configurat
 - (optional) [`ingress.yaml`](./cpu-config/ingress.yaml): contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
-kubectl apply -f cpu-config/
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/tei-deployment/cpu-config
 ```
 
 > [!NOTE]
-> As already mentioned, for this example you will be deploying the container in a CPU node, but the configuration to deploy TEI in a GPU node is also available in the [`gpu-config`](./gpu-config/) directory, so if you want to deploy TEI in a GPU node, please run `kubectl apply -f gpu-config/` instead of `kubectl apply -f cpu-config/`.
+> As already mentioned, for this example you will be deploying the container in a CPU node, but the configuration to deploy TEI in a GPU node is also available in the [`gpu-config`](./gpu-config/) directory, so if you want to deploy TEI in a GPU node, please run `kubectl apply -f Google-Cloud-Containers/examples/gke/tei-deployment/gpu-config` instead of `kubectl apply -f Google-Cloud-Containers/examples/gke/tei-deployment/cpu-config`.
 
 ![GKE Deployment in the GCP Console](./imgs/gke-deployment.png)
 

--- a/examples/gke/tei-from-gcs-deployment/README.md
+++ b/examples/gke/tei-from-gcs-deployment/README.md
@@ -158,11 +158,12 @@ The Hugging Face DLC for TEI will be deployed via `kubectl`, from the configurat
 - (optional) [`ingress.yaml`](./cpu-config/ingress.yaml): contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
-kubectl apply -f cpu-config/
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/tei-from-gcs-deployment/cpu-config
 ```
 
 > [!NOTE]
-> As already mentioned, for this example you will be deploying the container in a CPU node, but the configuration to deploy TEI in a GPU node is also available in the [`gpu-config`](./gpu-config/) directory, so if you want to deploy TEI in a GPU node, please run `kubectl apply -f gpu-config/` instead of `kubectl apply -f cpu-config/`.
+> As already mentioned, for this example you will be deploying the container in a CPU node, but the configuration to deploy TEI in a GPU node is also available in the [`gpu-config`](./gpu-config/) directory, so if you want to deploy TEI in a GPU node, please run `kubectl apply -f Google-Cloud-Containers/examples/gke/tei-from-gcs-deployment/gpu-config` instead of `kubectl apply -f Google-Cloud-Containers/examples/gke/tei-from-gcs-deployment/cpu-config`.
 
 ![GKE Deployment in the GCP Console](./imgs/gke-deployment.png)
 

--- a/examples/gke/tgi-deployment/README.md
+++ b/examples/gke/tgi-deployment/README.md
@@ -138,7 +138,8 @@ The Hugging Face DLC for TGI will be deployed via `kubectl`, from the configurat
 - (optional) [`ingress.yaml`](./config/ingress.yaml): contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
-kubectl apply -f config/
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/tgi-deployment/config
 ```
 
 ![GKE Deployment in the GCP Console](./imgs/gke-deployment.png)

--- a/examples/gke/tgi-from-gcs-deployment/README.md
+++ b/examples/gke/tgi-from-gcs-deployment/README.md
@@ -155,7 +155,8 @@ The Hugging Face DLC for TGI will be deployed via `kubectl`, from the configurat
 - (optional) [`ingress.yaml`](./config/ingress.yaml): contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
-kubectl apply -f config/
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/tgi-from-gcs-deployment/config
 ```
 
 ![GKE Deployment in the GCP Console](./imgs/gke-deployment.png)

--- a/examples/gke/tgi-llama-405b-deployment/README.md
+++ b/examples/gke/tgi-llama-405b-deployment/README.md
@@ -148,7 +148,8 @@ The Hugging Face DLC for TGI will be deployed via `kubectl`, from the configurat
 - (optional) [`ingress.yaml`](./config/ingress.yaml): contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
-kubectl apply -f config/
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/tgi-llama-405b-deployment/config
 ```
 
 > [!NOTE]

--- a/examples/gke/tgi-llama-vision-deployment/README.md
+++ b/examples/gke/tgi-llama-vision-deployment/README.md
@@ -143,7 +143,8 @@ The Hugging Face DLC for TGI will be deployed via `kubectl`, from the configurat
 - (optional) [`ingress.yaml`](./config/ingress.yaml): contains the ingress details of the pod, exposing the service to the external world so that it can be accessed via the ingress IP.
 
 ```bash
-kubectl apply -f config/
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/tgi-llama-vision-deployment/config
 ```
 
 > [!NOTE]

--- a/examples/gke/tgi-multi-lora-deployment/README.md
+++ b/examples/gke/tgi-multi-lora-deployment/README.md
@@ -143,7 +143,8 @@ The Hugging Face DLC for TGI will be deployed via `kubectl`, from the configurat
 > Note that the selected LoRA adapters are not intended to be used on production environments, as the fine-tuned adapters have not been tested extensively.
 
 ```bash
-kubectl apply -f config/
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/tgi-multi-lora-deployment/config
 ```
 
 > [!NOTE]

--- a/examples/gke/trl-full-fine-tuning/README.md
+++ b/examples/gke/trl-full-fine-tuning/README.md
@@ -166,7 +166,12 @@ Alternatively, if your model is uploaded to the Hugging Face Hub, you can check 
 Now you can already run the Kubernetes job in the Hugging Face PyTorch DLC for training on the GKE Cluster via `kubectl` from the [`job.yaml`](./job.yaml) configuration file, that contains the job specification for running the command `trl sft` provided by the TRL CLI for the SFT full fine-tuning of [`google/gemma-2b`](https://huggingface.co/google/gemma-2b) in `bfloat16` using [`timdettmers/openassistant-guanaco`](https://huggingface.co/datasets/timdettmers/openassistant-guanaco), which is a subset from [`OpenAssistant/oasst1`](https://huggingface.co/datasets/OpenAssistant/oasst1) with ~10k samples in 4 x A100 40GiB GPUs, storing the generated artifacts into a volume mount under `/data` linked to a GCS Bucket.
 
 ```bash
-kubectl apply -f job.yaml
+
+```
+
+```bash
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/trl-full-fine-tuning/job.yaml
 ```
 
 ![GKE Job Created in the GCP Console](./imgs/gke-job-created.png)

--- a/examples/gke/trl-lora-fine-tuning/README.md
+++ b/examples/gke/trl-lora-fine-tuning/README.md
@@ -166,7 +166,8 @@ Alternatively, if your model is uploaded to the Hugging Face Hub, you can check 
 Now you can already run the Kubernetes job in the Hugging Face PyTorch DLC for training on the GKE Cluster via `kubectl` from the [`job.yaml`](./job.yaml) configuration file, that contains the job specification for running the command `trl sft` provided by the TRL CLI for the SFT LoRA fine-tuning of [`mistralai/Mistral-7B-v0.3`](https://huggingface.co/mistralai/Mistral-7B-v0.3) in `bfloat16` using [`timdettmers/openassistant-guanaco`](https://huggingface.co/datasets/timdettmers/openassistant-guanaco), which is a subset from [`OpenAssistant/oasst1`](https://huggingface.co/datasets/OpenAssistant/oasst1) with ~10k samples in a single L4 24GiB GPU, storing the generated artifacts into a volume mount under `/data` linked to a GCS Bucket.
 
 ```bash
-kubectl apply -f job.yaml
+git clone https://github.com/huggingface/Google-Cloud-Containers
+kubectl apply -f Google-Cloud-Containers/examples/gke/trl-lora-fine-tuning/job.yaml
 ```
 
 ![GKE Job Created in the GCP Console](./imgs/gke-job-created.png)


### PR DESCRIPTION
## Description

This PR just adds the `git clone` command before the `kubectl apply -f` so that the users know where does the configuration come from; this is an iteration after #114, since even though the GitHub references have been included, is still not so clear where do those files come from; adding the `git clone` command leaves no space for doubt.