### PR TITLE
Fix `entrypoint.sh` and `huggingface-inference-toolkit` version in PyTorch Inference DLCs

### DIFF
--- a/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update && \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Hugging Face Inference Toolkit
-ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.2
+ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}
-RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st,google]"
+RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st]"
 
 # copy entrypoint and change permissions
 COPY --chmod=0755 containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh entrypoint.sh

--- a/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get update && \
     && apt-get clean autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
+# Prevent `huggingface_hub>0.26.0` from being installed later on
+RUN pip install "huggingface_hub[hf_transfer]<0.26.0"
+
 # Hugging Face Inference Toolkit
 ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}

--- a/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh
+++ b/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh
@@ -9,4 +9,4 @@ if [[ ! -z "${AIP_MODE}" ]]; then
 fi
 
 # Start the server
-uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}
+exec uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}

--- a/containers/pytorch/inference/cpu/2.2.2/transformers/4.44.0/py311/entrypoint.sh
+++ b/containers/pytorch/inference/cpu/2.2.2/transformers/4.44.0/py311/entrypoint.sh
@@ -35,4 +35,4 @@ if [[ $AIP_STORAGE_URI == gs://* ]]; then
 fi
 
 # Start the server
-uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}
+exec uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}

--- a/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get update && \
     && apt-get clean autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
+# Prevent `huggingface_hub>0.26.0` from being installed later on
+RUN pip install "huggingface_hub[hf_transfer]<0.26.0"
+
 # Hugging Face Inference Toolkit
 ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}

--- a/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update && \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Hugging Face Inference Toolkit
-ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.2
+ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}
-RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st,google]"
+RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st]"
 
 # copy entrypoint and change permissions
 COPY --chmod=0755 containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh entrypoint.sh

--- a/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh
+++ b/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh
@@ -9,4 +9,4 @@ if [[ ! -z "${AIP_MODE}" ]]; then
 fi
 
 # Start the server
-uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}
+exec uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}

--- a/containers/pytorch/inference/gpu/2.2.2/transformers/4.44.0/py311/entrypoint.sh
+++ b/containers/pytorch/inference/gpu/2.2.2/transformers/4.44.0/py311/entrypoint.sh
@@ -35,4 +35,4 @@ if [[ $AIP_STORAGE_URI == gs://* ]]; then
 fi
 
 # Start the server
-uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}
+exec uvicorn huggingface_inference_toolkit.webservice_starlette:app --host 0.0.0.0 --port ${PORT}


### PR DESCRIPTION
## Description

This PR fixes the version of `huggingface-inference-toolkit` pinned within both DLCs:

- us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-inference-cu121.2-2.transformers.4-41.ubuntu2204.py311
- us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-pytorch-inference-cpu.2-2.transformers.4-41.ubuntu2204.py311

As the `huggingface-inference-toolkit` version was pinned to a more recent one (0.4.2) instead of 0.4.1, that's due to the version pinning on `huggingface-inference-toolkit` that happened before releasing it publicly.

Additionally, this PR also adds the `exec` before the `uvicorn` command in the `entrypoint.sh` files so as to fix the signal handling for gracefully shutting it down.

Finally, this PR also installs the correct version of `huggingface_hub` before installing the `huggingface-inference-toolkit` to prevent the latest from being installed, which deprecates the `cached_download` method used by other dependencies.