### PR TITLE
Add missing `google-cloud-storage` dependency in PyTorch DLC

### DIFF
--- a/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -39,6 +39,9 @@ ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}
 RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st]"
 
+# Install google-cloud-storage required to download artifacts from Google Cloud Storage buckets
+RUN pip install --upgrade google-cloud-storage
+
 # copy entrypoint and change permissions
 COPY --chmod=0755 containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh entrypoint.sh
 ENTRYPOINT ["bash", "-c", "./entrypoint.sh"]

--- a/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -39,6 +39,9 @@ ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}
 RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st]"
 
+# Install google-cloud-storage required to download artifacts from Google Cloud Storage buckets
+RUN pip install --upgrade google-cloud-storage
+
 # copy entrypoint and change permissions
 COPY --chmod=0755 containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/entrypoint.sh entrypoint.sh
 ENTRYPOINT ["bash", "-c", "./entrypoint.sh"]


### PR DESCRIPTION
## Description

This PR is a follow up of #120 as reported by @xuyifann due to a missing dependency for `google-cloud-storage` within the Hugging Face PyTorch DLC for Inference on both CPU and GPU for the `transformers` version 4.41.0; as when patching the DLC in #120, that dependency was missing, but was catched during the testing after building the DLC.

This PR then adds the missing `google-cloud-storage` dependency within the Dockerfile, to patch that exact DLC, whilst the rest work fine, since those dependencies are installed as part of the `google` extra of `huggingface-inference-toolkit`, not available within the pinned `huggingface-inference-toolkit` version installed in this DLC in particular.