### PR TITLE
Fix `text-generation-server` dependency installation from `poetry.lock`

### DIFF
--- a/containers/tgi/gpu/2.1.1/Dockerfile
+++ b/containers/tgi/gpu/2.1.1/Dockerfile
@@ -242,7 +242,10 @@ COPY --from=tgi /tgi/server/Makefile server/Makefile
 RUN cd server && \
     make gen-server && \
     pip install -r requirements_cuda.txt && \
-    pip install ".[bnb, accelerate, quantize, peft, outlines]" --no-cache-dir
+    pip install poetry && \
+    poetry export -f requirements.txt --extras "bnb accelerate quantize peft outlines" --output requirements_poetry.txt && \
+    pip install -r requirements_poetry.txt && \
+    pip install .
 
 # Deps before the binaries
 # The binaries change on every build given we burn the SHA into them


### PR DESCRIPTION
## Description

This PR fixes the `Dockerfile` for the DLC for TGI 2.1.1; as the rebuilds of the container was failing because there was a conflict with the dependencies most likely due to loose pining on those, but since the `poetry.lock` is available within the repository, the safest would be to install those dependencies from the requirements pinned within the lock.

Thanks @xuyifann for internally reporting the error.