### PR TITLE
Fix pinned `huggingface-inference-toolkit` to include path patch

### DIFF
--- a/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update && \
 # Prevent `huggingface_hub>0.26.0` from being installed later on
 RUN pip install "huggingface_hub[hf_transfer]<0.26.0"
 
-# Hugging Face Inference Toolkit
-ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
+# Hugging Face Inference Toolkit (version 0.4.1 + path fix)
+ARG HF_INFERENCE_TOOLKIT_VERSION=58b760fe3ec4cbddf064ac62c7a3f745af136d5f
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}
 RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st]"
 

--- a/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.2.2/transformers/4.41.1/py311/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update && \
 # Prevent `huggingface_hub>0.26.0` from being installed later on
 RUN pip install "huggingface_hub[hf_transfer]<0.26.0"
 
-# Hugging Face Inference Toolkit
-ARG HF_INFERENCE_TOOLKIT_VERSION=0.4.1
+# Hugging Face Inference Toolkit (version 0.4.1 + path fix)
+ARG HF_INFERENCE_TOOLKIT_VERSION=58b760fe3ec4cbddf064ac62c7a3f745af136d5f
 ARG HF_INFERENCE_TOOLKIT_URL=git+https://github.com/huggingface/huggingface-inference-toolkit.git@${HF_INFERENCE_TOOLKIT_VERSION}
 RUN pip install "${HF_INFERENCE_TOOLKIT_URL}#egg=huggingface-inference-toolkit[torch,diffusers,st]"
 


### PR DESCRIPTION
## Description

As a follow up of #124, this PR updates the pinned version so that it points to https://github.com/huggingface/huggingface-inference-toolkit/pull/76 instead, as it contains a fix for the Google Cloud Storage (GCS) path downloads.

To reproduce locally one can run the following:

> [!WARNING]
> The command below assumes that `huggingface-pytorch-inference-cpu.2.2.2.transformers.4.41.0.py311` is the local Docker image name built as:
> ```bash
> docker build --platform=linux/amd64 -t huggingface-pytorch-inference-cpu.2.2.2.transformers.4.41.0.py311 -f containers/pytorch/inference/cpu/2.2.2/transformers/4.41.1/py311/Dockerfile .
> ```
>
> And that the `AIP_STORAGE_URI` is pointing to a valid bucket on GCS, with a Transformers compatible model.

```bash
docker run --platform linux/amd64 -v ~/.config/gcloud:/root/.config/gcloud -e GOOGLE_APPLICATION_CREDENTIALS="/root/.config/gcloud/application_default_credentials.json" -e GOOGLE_CLOUD_PROJECT="yout-project-id" -e HF_TASK="your-task" -e AIP_STORAGE_URI="your-bucket-path" huggingface-pytorch-inference-cpu.2.2.2.transformers.4.41.0.py311
```