### PR TITLE
Fix `mountPath` to use `/tmp` instead of `/data`

### DIFF
--- a/examples/gke/tei-deployment/cpu-config/deployment.yaml
+++ b/examples/gke/tei-deployment/cpu-config/deployment.yaml
@@ -32,10 +32,10 @@ spec:
             - name: PORT
               value: "8080"
           volumeMounts:
-            - mountPath: /data
-              name: data
+            - mountPath: /tmp
+              name: tmp
       volumes:
-        - name: data
+        - name: tmp
           emptyDir: {}
       nodeSelector:
         cloud.google.com/compute-class: "Performance"

--- a/examples/gke/tei-deployment/gpu-config/deployment.yaml
+++ b/examples/gke/tei-deployment/gpu-config/deployment.yaml
@@ -30,14 +30,14 @@ spec:
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
-            - mountPath: /data
-              name: data
+            - mountPath: /tmp
+              name: tmp
       volumes:
         - name: dshm
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
-        - name: data
+        - name: tmp
           emptyDir: {}
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-tesla-t4

--- a/examples/gke/tgi-deployment/config/deployment.yaml
+++ b/examples/gke/tgi-deployment/config/deployment.yaml
@@ -35,14 +35,14 @@ spec:
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
-            - mountPath: /data
-              name: data
+            - mountPath: /tmp
+              name: tmp
       volumes:
         - name: dshm
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
-        - name: data
+        - name: tmp
           emptyDir: {}
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-l4

--- a/examples/gke/tgi-llama-405b-deployment/config/deployment.yaml
+++ b/examples/gke/tgi-llama-405b-deployment/config/deployment.yaml
@@ -35,14 +35,14 @@ spec:
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
-            - mountPath: /data
-              name: data
+            - mountPath: /tmp
+              name: tmp
       volumes:
         - name: dshm
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
-        - name: data
+        - name: tmp
           emptyDir: {}
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-h100-80gb

--- a/examples/gke/tgi-llama-vision-deployment/config/deployment.yaml
+++ b/examples/gke/tgi-llama-vision-deployment/config/deployment.yaml
@@ -30,14 +30,14 @@ spec:
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
-            - mountPath: /data
-              name: data
+            - mountPath: /tmp
+              name: tmp
       volumes:
         - name: dshm
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
-        - name: data
+        - name: tmp
           emptyDir: {}
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-l4

--- a/examples/gke/tgi-multi-lora-deployment/config/deployment.yaml
+++ b/examples/gke/tgi-multi-lora-deployment/config/deployment.yaml
@@ -37,14 +37,14 @@ spec:
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
-            - mountPath: /data
-              name: data
+            - mountPath: /tmp
+              name: tmp
       volumes:
         - name: dshm
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
-        - name: data
+        - name: tmp
           emptyDir: {}
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-l4


### PR DESCRIPTION
## Description

This PR updates some `mountPath` references that were still pointing to `/data` instead of `/tmp`; whilst `/data` was the default `HF_HOME` only in [the default TGI Dockerfile within the TGI repository](https://github.com/huggingface/text-generation-inference/blob/main/Dockerfile), and within the following (already published) TGI DLCs on Google Cloud: [TGI 1.4.2](https://github.com/huggingface/Google-Cloud-Containers/blob/1c31c519b71cda5329bb7284ad521429302b7b73/containers/tgi/gpu/1.4.2/Dockerfile#L186), [TGI 1.4.4](https://github.com/huggingface/Google-Cloud-Containers/blob/1c31c519b71cda5329bb7284ad521429302b7b73/containers/tgi/gpu/1.4.4/Dockerfile#L186), [TGI 2.0.0](https://github.com/huggingface/Google-Cloud-Containers/blob/1c31c519b71cda5329bb7284ad521429302b7b73/containers/tgi/gpu/2.0.0/Dockerfile#L180), and [TGI 2.0.1](https://github.com/huggingface/Google-Cloud-Containers/blob/1c31c519b71cda5329bb7284ad521429302b7b73/containers/tgi/gpu/2.0.1/Dockerfile#L180); but udpated to `/tmp` from [the TGI 2.3.0 DLC onwards](https://github.com/huggingface/Google-Cloud-Containers/blob/1c31c519b71cda5329bb7284ad521429302b7b73/containers/tgi/gpu/2.0.3/Dockerfile#L178).

Originally reported at https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/1581, and solved at both https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/1584 and https://github.com/GoogleCloudPlatform/ai-on-gke/pull/852.