### PR TITLE
Pin `cargo-chef` version on TEI DLCs on GPU

### DIFF
--- a/containers/tei/cpu/1.2.2/Dockerfile
+++ b/containers/tei/cpu/1.2.2/Dockerfile
@@ -1,4 +1,4 @@
-# Fetch and extract the TGI sources
+# Fetch and extract the TEI sources
 FROM alpine AS tei
 RUN mkdir -p /tei
 ADD https://github.com/huggingface/text-embeddings-inference/archive/refs/tags/v1.2.2.tar.gz /tei/sources.tar.gz

--- a/containers/tei/cpu/1.4.0/Dockerfile
+++ b/containers/tei/cpu/1.4.0/Dockerfile
@@ -1,4 +1,4 @@
-# Fetch and extract the TGI sources
+# Fetch and extract the TEI sources
 FROM alpine AS tei
 
 RUN mkdir -p /tei

--- a/containers/tei/cpu/1.5.1/Dockerfile
+++ b/containers/tei/cpu/1.5.1/Dockerfile
@@ -1,4 +1,4 @@
-# Fetch and extract the TGI sources
+# Fetch and extract the TEI sources
 FROM alpine AS tei
 
 RUN mkdir -p /tei

--- a/containers/tei/gpu/1.2.2/Dockerfile
+++ b/containers/tei/gpu/1.2.2/Dockerfile
@@ -1,4 +1,4 @@
-# Fetch and extract the TGI sources
+# Fetch and extract the TEI sources
 FROM alpine AS tei
 RUN mkdir -p /tei
 ADD https://github.com/huggingface/text-embeddings-inference/archive/refs/tags/v1.2.2.tar.gz /tei/sources.tar.gz

--- a/containers/tei/gpu/1.2.2/Dockerfile
+++ b/containers/tei/gpu/1.2.2/Dockerfile
@@ -10,6 +10,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS base-builder
 ENV SCCACHE=0.5.4
 ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
+# aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm` 
+ENV CARGO_CHEF=0.1.62
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -17,12 +19,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Download and configure sccache
+# Donwload and configure sccache
 RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sccache-v$SCCACHE-x86_64-unknown-linux-musl.tar.gz | tar -xzv --strip-components=1 -C /usr/local/bin sccache-v$SCCACHE-x86_64-unknown-linux-musl/sccache && \
     chmod +x /usr/local/bin/sccache
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
 

--- a/containers/tei/gpu/1.4.0/Dockerfile
+++ b/containers/tei/gpu/1.4.0/Dockerfile
@@ -11,6 +11,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS base-builder
 ENV SCCACHE=0.5.4
 ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
+# aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm` 
+ENV CARGO_CHEF=0.1.62
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -18,12 +20,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Download and configure sccache
+# Donwload and configure sccache
 RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sccache-v$SCCACHE-x86_64-unknown-linux-musl.tar.gz | tar -xzv --strip-components=1 -C /usr/local/bin sccache-v$SCCACHE-x86_64-unknown-linux-musl/sccache && \
     chmod +x /usr/local/bin/sccache
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
 

--- a/containers/tei/gpu/1.4.0/Dockerfile
+++ b/containers/tei/gpu/1.4.0/Dockerfile
@@ -1,4 +1,4 @@
-# Fetch and extract the TGI sources
+# Fetch and extract the TEI sources
 FROM alpine AS tei
 
 RUN mkdir -p /tei

--- a/containers/tei/gpu/1.5.1/Dockerfile
+++ b/containers/tei/gpu/1.5.1/Dockerfile
@@ -11,6 +11,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS base-builder
 ENV SCCACHE=0.5.4
 ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
+# aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm` 
+ENV CARGO_CHEF=0.1.62
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -23,7 +25,7 @@ RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sc
     chmod +x /usr/local/bin/sccache
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
 

--- a/containers/tei/gpu/1.5.1/Dockerfile
+++ b/containers/tei/gpu/1.5.1/Dockerfile
@@ -1,4 +1,4 @@
-# Fetch and extract the TGI sources
+# Fetch and extract the TEI sources
 FROM alpine AS tei
 
 RUN mkdir -p /tei

--- a/containers/tei/gpu/1.6.0/Dockerfile
+++ b/containers/tei/gpu/1.6.0/Dockerfile
@@ -11,6 +11,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS base-builder
 ENV SCCACHE=0.5.4
 ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
+# aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm` 
+ENV CARGO_CHEF=0.1.62
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -23,7 +25,7 @@ RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sc
     chmod +x /usr/local/bin/sccache
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
 


### PR DESCRIPTION
## Description

This PR pins the `cargo-chef` version being installed on the `Dockerfile` images for TEI on CUDA, since the latest raises the following issue when running `cargo chef prepare --features google --recipe-path recipe.json` with the following exception:

```
0.294 error: failed to parse manifest at `/usr/src/router/Cargo.toml`                                                                                                                                                                                       
0.294                                                                                                                                                                                                                                                       
0.294 Caused by:                                                                                                                                                                                                                                            
0.294   the target `text-embeddings-router` is a binary and can't have any crate-types set (currently "bin")
0.296 thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-chef-0.1.69/src/recipe.rs:218:27:
```

More information about the issue at https://github.com/huggingface/text-embeddings-inference/pull/469.