### PR TITLE
Add details about TPUs in the docs

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -3,8 +3,11 @@
       title: Hugging Face on Google Cloud
     - local: features
       title: Features & benefits
+    - local: tpu
+      title: Using TPUs on Google Cloud
     - local: resources
       title: Other Resources
+
   title: Getting Started
 - sections:
     - local: containers/introduction

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -7,7 +7,6 @@
       title: Using TPUs on Google Cloud
     - local: resources
       title: Other Resources
-
   title: Getting Started
 - sections:
     - local: containers/introduction

--- a/docs/source/tpu.mdx
+++ b/docs/source/tpu.mdx
@@ -1,3 +1,3 @@
-# TPU Support
+# Using TPUs on Google Cloud
 
 To learn how to use Google Cloud TPUs with Hugging Face libraries, check out [optimum-tpu](https://huggingface.co/docs/optimum-tpu), our dedicated library for TPU support.

--- a/docs/source/tpu.mdx
+++ b/docs/source/tpu.mdx
@@ -1,0 +1,3 @@
+# TPU Support
+
+To learn how to use Google Cloud TPUs with Hugging Face libraries, check out [optimum-tpu](https://huggingface.co/docs/optimum-tpu), our dedicated library for TPU support.


### PR DESCRIPTION
This PR adds a link to optimum-tpu in the docs so that users of Google Cloud that are interested in TPUs can look at optimum-tpu for more in-depth information on TPUs