### PR TITLE
Add `docs/source/_redirects.yml`

### DIFF
--- a/docs/source/_redirects.yml
+++ b/docs/source/_redirects.yml
@@ -1,0 +1,1 @@
+examples/cloud-run-tgi-deployment: examples/cloud-run-deploy-llama-3-1-on-cloud-run


### PR DESCRIPTION
## Description

This PR adds a redirection rule from https://huggingface/docs/google-cloud/en/examples/cloud-run-tgi-deployment to https://huggingface.co/docs/google-cloud/main/en/examples/cloud-run-deploy-llama-3-1-on-cloud-run; as the page was originally named that way but renamed to be model specific after the Gemma2 9B example was created.

Fixes #146, thanks to @steren for reporting and @philschmid for the ping!