### PR TITLE
Set `PATH` and `LD_LIBRARY_PATH` on CUDA for Vertex AI

### DIFF
--- a/containers/pytorch/inference/gpu/2.7.1/transformers/4.57.3/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.7.1/transformers/4.57.3/py311/Dockerfile
@@ -87,5 +87,8 @@ RUN uv pip install google-cloud-storage crcmod --upgrade
 COPY --chown=huggingface:huggingface containers/pytorch/inference/gpu/2.7.1/transformers/4.57.3/py311/entrypoint.sh .
 RUN chmod +x /home/huggingface/entrypoint.sh
 
+ENV PATH="/usr/local/nvidia/bin:$PATH" \
+    LD_LIBRARY_PATH="/usr/local/nvidia/lib64:$LD_LIBRARY_PATH"
+
 USER huggingface
 ENTRYPOINT ["/home/huggingface/entrypoint.sh"]

--- a/containers/tei/gpu/1.8.3/Dockerfile
+++ b/containers/tei/gpu/1.8.3/Dockerfile
@@ -85,7 +85,9 @@ FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS base
 
 ENV HUGGINGFACE_HUB_CACHE=/tmp \
     PORT=8080 \
-    USE_FLASH_ATTENTION=True
+    USE_FLASH_ATTENTION=True \
+    PATH="/usr/local/nvidia/bin:$PATH" \
+    LD_LIBRARY_PATH="/usr/local/nvidia/lib64:$LD_LIBRARY_PATH"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/containers/tei/gpu/1.9.2/Dockerfile
+++ b/containers/tei/gpu/1.9.2/Dockerfile
@@ -111,7 +111,8 @@ FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04 AS base
 ENV HUGGINGFACE_HUB_CACHE=/tmp \
     PORT=8080 \
     USE_FLASH_ATTENTION=True \
-    LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+    PATH="/usr/local/nvidia/bin:$PATH" \
+    LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/nvidia/lib64:$LD_LIBRARY_PATH"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     apt-transport-https \


### PR DESCRIPTION
## Description

This PR sets both the `PATH` and `LD_LIBRARY_PATH` environment variables on the recently released CUDA images for PyTorch Inference at #151 and Text Embeddings Inference at #153, pointing to the NVIDIA Driver libraries for the containers to work on Vertex AI and properly identify the CUDA devices there.

Note that these environment variables are usually populated on runtime by the NVIDIA Container Toolkit, hence not required to be set in advance, but as per Dustin Loung from the Vertex AI team at Google Cloud reported, those seem to be required on Vertex AI.