### PR TITLE
Fix installation command for transformers package

### DIFF
--- a/examples/vertex-ai/notebooks/fine-tune-gemma-4/vertex-notebook.ipynb
+++ b/examples/vertex-ai/notebooks/fine-tune-gemma-4/vertex-notebook.ipynb
@@ -258,7 +258,7 @@
     "RUN uv pip install \"torch==2.10.0\" torchvision torchaudio --torch-backend=cu126\n",
     "\n",
     "RUN uv pip install --no-cache-dir \\\n",
-    "    \"transformers[audio,chat_template,kernels,video,vision]>=5.5.0\"\n",
+    "    \"transformers[audio,chat_template,kernels,video,vision]>=5.5.0\" \\\n",
     "    \"huggingface_hub[hf_xet]==1.8.0\" \\\n",
     "    \"datasets==4.8.4\" \\\n",
     "    \"accelerate==1.13.0\" \\\n",


### PR DESCRIPTION
I was testing out this example and noticed that there's a missing backslash that causes the next command to produce an error. Specificall: `!gcloud builds submit --tag $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY_NAME/$IMAGE_NAME:latest .` 

PS: I hope this is the correct file, I was trying it here: https://huggingface.co/docs/google-cloud/examples/vertex-ai-notebooks-fine-tune-gemma-4