### PR TITLE
Patch remaning CRITICAL CVEs on Text Embeddings Inference DLC

### DIFF
--- a/containers/tei/cpu/1.9.3/Dockerfile
+++ b/containers/tei/cpu/1.9.3/Dockerfile
@@ -102,6 +102,9 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 # Which are originated due to the bundled Go version in the pre-compiled anthoscli
 RUN rm -rf /usr/lib/google-cloud-sdk/bin/anthoscli
 
+# NOTE: CVE-2026-42010 and CVE-2026-33845
+RUN apt-get update && apt-get upgrade -y dpkg && rm -rf /var/lib/apt/lists/*
+
 COPY --chmod=775 containers/tei/cpu/1.9.3/entrypoint.sh entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["--json-output"]


### PR DESCRIPTION
## Description

This PR patches the remaining CRITICAL CVEs on Text Embeddings Inference (TEI) DLC v1.9.3 on CPU, by patching `dpkg` upgrading to 3.7.9 2+deb12u7 or higher.