### PR TITLE
Update DLCs for both PyTorch Training and Inference

### DIFF
--- a/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -81,11 +81,12 @@ WORKDIR /home/huggingface
 # CVE-2025-47273: setuptools>=78.1.1
 # CVE-2026-42311, CVE-2026-40192: Pillow>=12.2
 # CVE-2026-26007: cryptography>=46.0.5
+# GHSA-537c-gmf6-5ccf: cryptography>=48.0.1
 # CVE-2026-27459: pyopenssl>=26
 RUN uv pip install \
     "setuptools>=78.1.1" \
     "Pillow>=12.2" \
-    "cryptography>=46.0.5" \
+    "cryptography>=48.0.1" \
     "pyopenssl>=26" \
     --upgrade
 

--- a/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -97,7 +97,7 @@ RUN uv pip install --no-cache-dir \
     "diffusers[kernels]==0.39.0" \
     "sentence-transformers==5.6.0"
 
-RUN uv pip install "hf-serve[cpu]==0.1.2"
+RUN uv pip install "hf-serve[cpu]==0.1.3"
 
 RUN uv pip install --no-cache-dir \
     google-cloud-storage \

--- a/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -1,0 +1,109 @@
+FROM ubuntu:24.04
+LABEL maintainer="Hugging Face"
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    build-essential \
+    git \
+    gnupg \
+    # NOTE: `ffmpeg` and `libmagic-dev` are required for audio related tasks
+    # NOTE: `ffmpeg` version is constrained < 8, as it's a `torchcodec` requirement
+    ffmpeg=7:* \
+    libmagic-dev \
+    # NOTE: `espeak-ng` is the backend used by `phonemizer` so adding it here only
+    # tentatively as it's most likely "too specific" for models relying on `phonemizer`
+    # as e.g. https://huggingface.co/facebook/wav2vec2-lv-60-espeak-cv-ft
+    espeak-ng \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update -y && \
+    apt-get install google-cloud-cli -y && \
+    apt-get clean autoremove --yes && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}
+
+# NOTE: anthoscli is not required for the intended use of gcloud SDK within this
+# context, hence we're safe to remove it, preventing the following CVEs:
+# - CVE-2025-68121
+# - CVE-2026-27143
+# - CVE-2026-33186
+# Which are originated due to the bundled Go version in the pre-compiled anthoscli
+RUN rm -rf /usr/lib/google-cloud-sdk/bin/anthoscli
+
+# NOTE: nic_sampler is not required for inference workloads, and is removed to
+# prevent CVEs originating from the bundled Go version used to compile it
+# - CVE-2025-22871
+# - CVE-2026-33186
+# - CVE-2024-24790
+# - CVE-2026-27143
+# - CVE-2025-68121
+RUN rm -f /opt/nvidia/nsight-compute/2025.1.1/host/target-linux-x64/plugins/efa_metrics/nic_sampler
+
+# NOTE: Inference Endpoints API writes the Hugging Face Hub repository in
+# `/repository` hence it should allow any user to read from it
+RUN mkdir -p /repository && chmod 755 /repository
+
+# NOTE: GID and UID set to 1001 instead of standard 1000, given that's reserved
+# for the default non-root Ubuntu user
+RUN groupadd --gid 1001 huggingface \
+    && useradd --uid 1001 --gid huggingface --shell /bin/bash --create-home huggingface
+
+# Create the /opt/huggingface directory and set correct owner and permissions,
+# given that's the directory formerly used for the Vertex AI DLCs
+RUN mkdir -p /opt/huggingface \
+    && chown 1001:1001 /opt/huggingface \
+    && chmod 755 /opt/huggingface
+
+USER huggingface
+WORKDIR /home/huggingface
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/huggingface/.cargo/bin:/home/huggingface/.local/bin/:$PATH"
+
+RUN uv python install 3.11
+
+RUN uv venv /home/huggingface/venv --python 3.11
+ENV VIRTUAL_ENV=/home/huggingface/venv \
+    PATH="/home/huggingface/venv/bin:$PATH"
+
+WORKDIR /home/huggingface
+
+# CVE-2025-47273: setuptools>=78.1.1
+# CVE-2026-42311, CVE-2026-40192: Pillow>=12.2
+# CVE-2026-26007: cryptography>=46.0.5
+# CVE-2026-27459: pyopenssl>=26
+RUN uv pip install \
+    "setuptools>=78.1.1" \
+    "Pillow>=12.2" \
+    "cryptography>=46.0.5" \
+    "pyopenssl>=26" \
+    --upgrade
+
+RUN uv pip install "hf-serve[cpu]==0.1.1"
+
+RUN uv pip install --no-cache-dir \
+    google-cloud-storage \
+    google-cloud-bigquery \
+    google-cloud-aiplatform \
+    google-cloud-pubsub \
+    google-cloud-logging \
+    crcmod \
+    gcsfs
+
+RUN uv cache clean
+
+COPY --chown=huggingface:huggingface containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh .
+RUN chmod +x /home/huggingface/entrypoint.sh
+
+USER huggingface
+ENTRYPOINT ["/home/huggingface/entrypoint.sh"]

--- a/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -89,6 +89,13 @@ RUN uv pip install \
     "pyopenssl>=26" \
     --upgrade
 
+RUN uv pip install "torch==2.11.0" torchvision torchaudio --torch-backend=cpu
+
+RUN uv pip install --no-cache-dir \
+    "transformers[audio,chat_template,kernels,video,vision]==5.13.1" \
+    "diffusers[kernels]==0.39.0" \
+    "sentence-transformers==5.6.0"
+
 RUN uv pip install "hf-serve[cpu]==0.1.1"
 
 RUN uv pip install --no-cache-dir \

--- a/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -97,7 +97,7 @@ RUN uv pip install --no-cache-dir \
     "diffusers[kernels]==0.39.0" \
     "sentence-transformers==5.6.0"
 
-RUN uv pip install "hf-serve[cpu]==0.1.1"
+RUN uv pip install "hf-serve[cpu]==0.1.2"
 
 RUN uv pip install --no-cache-dir \
     google-cloud-storage \

--- a/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
+++ b/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -eo pipefail
+
+export CLOUD="google"
+
+# Default `PORT` is 5000, unless other port is provided via `AIP_HTTP_PORT` only
+# when `AIP_MODE` is set (usually set to `PREDICT`)
+readonly DEFAULT_PORT=5000
+if [[ ! -z "${AIP_MODE}" ]]; then
+    export PORT="${AIP_HTTP_PORT:-$DEFAULT_PORT}"
+else
+    export PORT="$DEFAULT_PORT"
+fi
+
+if [[ "${AIP_STORAGE_URI:-}" == gs://* ]]; then
+    echo "INFO: AIP_STORAGE_URI set and starts with 'gs://', proceeding to download from GCS."
+    echo "INFO: AIP_STORAGE_URI: $AIP_STORAGE_URI"
+
+    TARGET_DIR="/opt/huggingface/model"
+    mkdir -p "$TARGET_DIR"
+
+    if ! command -v gsutil &>/dev/null; then
+        echo "ERROR: gsutil command not found. Please install Google Cloud SDK." >&2
+        exit 1
+    fi
+
+    echo "INFO: Running: gsutil -m cp -e -r \"$AIP_STORAGE_URI/*\" \"$TARGET_DIR\""
+    if ! gsutil -m cp -e -r "$AIP_STORAGE_URI/*" "$TARGET_DIR"; then
+        echo "ERROR: Failed to download model from GCS." >&2
+        exit 1
+    fi
+
+    echo "INFO: Model downloaded successfully to ${TARGET_DIR}."
+    echo "INFO: Updating HF_MODEL_DIR to point to the local directory."
+
+    export HF_MODEL_DIR="$TARGET_DIR"
+fi
+
+# If `HF_MODEL_ID` is a path instead of a Hub ID, then clear its value and assign it
+# to the `HF_MODEL_DIR` instead, including a user warning
+if [[ -d "${HF_MODEL_ID:-}" ]]; then
+    echo "WARNING: HF_MODEL_ID is a path, please use HF_MODEL_DIR for paths instead."
+    export HF_MODEL_DIR="${HF_MODEL_ID}"
+    unset HF_MODEL_ID
+fi
+
+# If `HF_MODEL_DIR` is set, then unset it and set `MODEL_DIR` instead
+if [[ -n "${HF_MODEL_DIR:-}" ]]; then
+    if [[ -z "${MODEL_DIR:-}" ]]; then
+        export MODEL_DIR="${HF_MODEL_DIR}"
+    else
+        echo "WARNING: MODEL_DIR is already set to '${MODEL_DIR}', keeping its value."
+    fi
+    unset HF_MODEL_DIR
+fi
+
+# If `HF_DEFAULT_PIPELINE_NAME` is set, then unset it and set `CUSTOM_HANDLER_FILE` instead
+if [[ -n "${HF_DEFAULT_PIPELINE_NAME:-}" ]]; then
+    if [[ -z "${CUSTOM_HANDLER_FILE:-}" ]]; then
+        export CUSTOM_HANDLER_FILE="${HF_DEFAULT_PIPELINE_NAME}"
+    else
+        echo "WARNING: CUSTOM_HANDLER_FILE is already set to '${CUSTOM_HANDLER_FILE}', keeping its value."
+    fi
+    unset HF_DEFAULT_PIPELINE_NAME
+fi
+
+# If `MODEL_DIR` is set and is a valid directory
+if [[ -n "${MODEL_DIR:-}" ]]; then
+    if [[ ! -d "${MODEL_DIR}" ]]; then
+        echo "ERROR: Provided MODEL_DIR is not a valid directory" >&2
+        exit 1
+    fi
+
+    # Check if `requirements.txt` exists and if so install dependencies
+    if [[ -f "${MODEL_DIR}/requirements.txt" ]]; then
+        echo "INFO: Installing custom dependencies from ${MODEL_DIR}/requirements.txt"
+        uv pip install --active -r "${MODEL_DIR}/requirements.txt" --no-cache-dir
+
+        # Check if the custom handler file is missing when `requirements.txt` is present
+        if [[ ! -f "${MODEL_DIR}/${CUSTOM_HANDLER_FILE}" ]]; then
+            echo "WARNING: requirements.txt is present, but ${CUSTOM_HANDLER_FILE} is missing in ${MODEL_DIR}."
+            echo "WARNING: If you intend to run custom code, make sure to include ${CUSTOM_HANDLER_FILE}."
+        fi
+    fi
+fi
+
+exec hf-serve "$@"

--- a/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
+++ b/containers/pytorch/inference/cpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
@@ -2,13 +2,12 @@
 
 set -eo pipefail
 
-export CLOUD="google"
-
 # Default `PORT` is 5000, unless other port is provided via `AIP_HTTP_PORT` only
 # when `AIP_MODE` is set (usually set to `PREDICT`)
 readonly DEFAULT_PORT=5000
 if [[ ! -z "${AIP_MODE}" ]]; then
     export PORT="${AIP_HTTP_PORT:-$DEFAULT_PORT}"
+    export CLOUD="google"
 else
     export PORT="$DEFAULT_PORT"
 fi

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -93,11 +93,12 @@ WORKDIR /home/huggingface
 # CVE-2025-47273: setuptools>=78.1.1
 # CVE-2026-42311, CVE-2026-40192: Pillow>=12.2
 # CVE-2026-26007: cryptography>=46.0.5
+# GHSA-537c-gmf6-5ccf: cryptography>=48.0.1
 # CVE-2026-27459: pyopenssl>=26
 RUN uv pip install \
     "setuptools>=78.1.1" \
     "Pillow>=12.2" \
-    "cryptography>=46.0.5" \
+    "cryptography>=48.0.1" \
     "pyopenssl>=26" \
     --upgrade
 

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -1,0 +1,124 @@
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
+LABEL maintainer="Hugging Face"
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    build-essential \
+    git \
+    gnupg \
+    # NOTE: `ffmpeg` and `libmagic-dev` are required for audio related tasks
+    # NOTE: `ffmpeg` version is constrained < 8, as it's a `torchcodec` requirement
+    ffmpeg=7:* \
+    libmagic-dev \
+    # NOTE: `espeak-ng` is the backend used by `phonemizer` so adding it here only
+    # tentatively as it's most likely "too specific" for models relying on `phonemizer`
+    # as e.g. https://huggingface.co/facebook/wav2vec2-lv-60-espeak-cv-ft
+    espeak-ng \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# NOTE: `torchcodec` and hence the audio-related models as e.g. Wav2Vec, require
+# both `libnpp` and `libnvrtc` to be preset for it to work seamlessly on CUDA
+RUN if ! ldconfig -p | grep -q libnpp; then \
+    apt-get update && apt-get install -y --no-install-recommends libnpp-dev; \
+    fi && \
+    if ! ldconfig -p | grep -q libnvrtc; then \
+    apt-get update && apt-get install -y --no-install-recommends cuda-nvrtc-dev; \
+    fi && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update -y && \
+    apt-get install google-cloud-cli -y && \
+    apt-get clean autoremove --yes && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}
+
+# NOTE: anthoscli is not required for the intended use of gcloud SDK within this
+# context, hence we're safe to remove it, preventing the following CVEs:
+# - CVE-2025-68121
+# - CVE-2026-27143
+# - CVE-2026-33186
+# Which are originated due to the bundled Go version in the pre-compiled anthoscli
+RUN rm -rf /usr/lib/google-cloud-sdk/bin/anthoscli
+
+# NOTE: nic_sampler is not required for inference workloads, and is removed to
+# prevent CVEs originating from the bundled Go version used to compile it
+# - CVE-2025-22871
+# - CVE-2026-33186
+# - CVE-2024-24790
+# - CVE-2026-27143
+# - CVE-2025-68121
+RUN rm -f /opt/nvidia/nsight-compute/2025.1.1/host/target-linux-x64/plugins/efa_metrics/nic_sampler
+
+# NOTE: Inference Endpoints API writes the Hugging Face Hub repository in
+# `/repository` hence it should allow any user to read from it
+RUN mkdir -p /repository && chmod 755 /repository
+
+# NOTE: GID and UID set to 1001 instead of standard 1000, given that's reserved
+# for the default non-root Ubuntu user
+RUN groupadd --gid 1001 huggingface \
+    && useradd --uid 1001 --gid huggingface --shell /bin/bash --create-home huggingface
+
+# Create the /opt/huggingface directory and set correct owner and permissions,
+# given that's the directory formerly used for the Vertex AI DLCs
+RUN mkdir -p /opt/huggingface \
+    && chown 1001:1001 /opt/huggingface \
+    && chmod 755 /opt/huggingface
+
+USER huggingface
+WORKDIR /home/huggingface
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/huggingface/.cargo/bin:/home/huggingface/.local/bin/:$PATH"
+
+RUN uv python install 3.11
+
+RUN uv venv /home/huggingface/venv --python 3.11
+ENV VIRTUAL_ENV=/home/huggingface/venv \
+    PATH="/home/huggingface/venv/bin:$PATH"
+
+WORKDIR /home/huggingface
+
+# CVE-2025-47273: setuptools>=78.1.1
+# CVE-2026-42311, CVE-2026-40192: Pillow>=12.2
+# CVE-2026-26007: cryptography>=46.0.5
+# CVE-2026-27459: pyopenssl>=26
+RUN uv pip install \
+    "setuptools>=78.1.1" \
+    "Pillow>=12.2" \
+    "cryptography>=46.0.5" \
+    "pyopenssl>=26" \
+    --upgrade
+
+RUN uv pip install "hf-serve[cuda,flash-attn]==0.1.1"
+
+RUN uv pip install --no-cache-dir \
+    google-cloud-storage \
+    google-cloud-bigquery \
+    google-cloud-aiplatform \
+    google-cloud-pubsub \
+    google-cloud-logging \
+    crcmod \
+    gcsfs
+
+RUN uv cache clean
+
+COPY --chown=huggingface:huggingface containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh .
+RUN chmod +x /home/huggingface/entrypoint.sh
+
+ENV PATH="/usr/local/nvidia/bin:$PATH" \
+    LD_LIBRARY_PATH="/usr/local/nvidia/lib64:$LD_LIBRARY_PATH"
+
+USER huggingface
+ENTRYPOINT ["/home/huggingface/entrypoint.sh"]

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -109,7 +109,7 @@ RUN uv pip install --no-cache-dir \
     "diffusers[kernels]==0.39.0" \
     "sentence-transformers==5.6.0"
 
-RUN uv pip install "hf-serve[cuda-128]==0.1.2"
+RUN uv pip install "hf-serve[cuda-128]==0.1.3"
 
 RUN uv pip install --no-cache-dir \
     google-cloud-storage \

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -109,7 +109,11 @@ RUN uv pip install --no-cache-dir \
     "diffusers[kernels]==0.39.0" \
     "sentence-transformers==5.6.0"
 
-RUN uv pip install "hf-serve[cuda,flash-attn]==0.1.1"
+# NOTE: Likely both `psutil` and `torch` should be defined as build dependencies
+# for `flash-attn` to prevent manual install + `--no-build-isolation` later on
+RUN uv pip install psutil
+
+RUN uv pip install "hf-serve[cuda,flash-attn]==0.1.1" --no-build-isolation
 
 RUN uv pip install --no-cache-dir \
     google-cloud-storage \

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -109,11 +109,7 @@ RUN uv pip install --no-cache-dir \
     "diffusers[kernels]==0.39.0" \
     "sentence-transformers==5.6.0"
 
-# NOTE: Likely both `psutil` and `torch` should be defined as build dependencies
-# for `flash-attn` to prevent manual install + `--no-build-isolation` later on
-RUN uv pip install psutil
-
-RUN uv pip install "hf-serve[cuda,flash-attn]==0.1.1" --no-build-isolation
+RUN uv pip install "hf-serve[cuda]==0.1.2"
 
 RUN uv pip install --no-cache-dir \
     google-cloud-storage \

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -102,14 +102,14 @@ RUN uv pip install \
     "pyopenssl>=26" \
     --upgrade
 
-RUN uv pip install "torch==2.11.0" torchvision torchaudio --torch-backend=cu128
+RUN uv pip install "torch==2.11.0" torchvision "torchaudio==2.11.0" --torch-backend=cu128
 
 RUN uv pip install --no-cache-dir \
     "transformers[audio,chat_template,kernels,video,vision]==5.13.1" \
     "diffusers[kernels]==0.39.0" \
     "sentence-transformers==5.6.0"
 
-RUN uv pip install "hf-serve[cuda]==0.1.2"
+RUN uv pip install "hf-serve[cuda-128]==0.1.2"
 
 RUN uv pip install --no-cache-dir \
     google-cloud-storage \

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -101,6 +101,13 @@ RUN uv pip install \
     "pyopenssl>=26" \
     --upgrade
 
+RUN uv pip install "torch==2.11.0" torchvision torchaudio --torch-backend=cu128
+
+RUN uv pip install --no-cache-dir \
+    "transformers[audio,chat_template,kernels,video,vision]==5.13.1" \
+    "diffusers[kernels]==0.39.0" \
+    "sentence-transformers==5.6.0"
+
 RUN uv pip install "hf-serve[cuda,flash-attn]==0.1.1"
 
 RUN uv pip install --no-cache-dir \

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if ! command -v nvidia-smi &>/dev/null; then
+    echo "ERROR: nvidia-smi command not found, please use the CPU DLC instead."
+    exit 1
+fi
+
+export CLOUD="google"
+
+# Default `PORT` is 5000, unless other port is provided via `AIP_HTTP_PORT` only
+# when `AIP_MODE` is set (usually set to `PREDICT`)
+readonly DEFAULT_PORT=5000
+if [[ ! -z "${AIP_MODE}" ]]; then
+    export PORT="${AIP_HTTP_PORT:-$DEFAULT_PORT}"
+else
+    export PORT="$DEFAULT_PORT"
+fi
+
+if [[ "${AIP_STORAGE_URI:-}" == gs://* ]]; then
+    echo "INFO: AIP_STORAGE_URI set and starts with 'gs://', proceeding to download from GCS."
+    echo "INFO: AIP_STORAGE_URI: $AIP_STORAGE_URI"
+
+    TARGET_DIR="/opt/huggingface/model"
+    mkdir -p "$TARGET_DIR"
+
+    if ! command -v gsutil &>/dev/null; then
+        echo "ERROR: gsutil command not found. Please install Google Cloud SDK." >&2
+        exit 1
+    fi
+
+    echo "INFO: Running: gsutil -m cp -e -r \"$AIP_STORAGE_URI/*\" \"$TARGET_DIR\""
+    if ! gsutil -m cp -e -r "$AIP_STORAGE_URI/*" "$TARGET_DIR"; then
+        echo "ERROR: Failed to download model from GCS." >&2
+        exit 1
+    fi
+
+    echo "INFO: Model downloaded successfully to ${TARGET_DIR}."
+    echo "INFO: Updating HF_MODEL_DIR to point to the local directory."
+
+    export HF_MODEL_DIR="$TARGET_DIR"
+fi
+
+# If `HF_MODEL_ID` is a path instead of a Hub ID, then clear its value and assign it
+# to the `HF_MODEL_DIR` instead, including a user warning
+if [[ -d "${HF_MODEL_ID:-}" ]]; then
+    echo "WARNING: HF_MODEL_ID is a path, please use HF_MODEL_DIR for paths instead."
+    export HF_MODEL_DIR="${HF_MODEL_ID}"
+    unset HF_MODEL_ID
+fi
+
+# If `HF_MODEL_DIR` is set, then unset it and set `MODEL_DIR` instead
+if [[ -n "${HF_MODEL_DIR:-}" ]]; then
+    if [[ -z "${MODEL_DIR:-}" ]]; then
+        export MODEL_DIR="${HF_MODEL_DIR}"
+    else
+        echo "WARNING: MODEL_DIR is already set to '${MODEL_DIR}', keeping its value."
+    fi
+    unset HF_MODEL_DIR
+fi
+
+# If `HF_DEFAULT_PIPELINE_NAME` is set, then unset it and set `CUSTOM_HANDLER_FILE` instead
+if [[ -n "${HF_DEFAULT_PIPELINE_NAME:-}" ]]; then
+    if [[ -z "${CUSTOM_HANDLER_FILE:-}" ]]; then
+        export CUSTOM_HANDLER_FILE="${HF_DEFAULT_PIPELINE_NAME}"
+    else
+        echo "WARNING: CUSTOM_HANDLER_FILE is already set to '${CUSTOM_HANDLER_FILE}', keeping its value."
+    fi
+    unset HF_DEFAULT_PIPELINE_NAME
+fi
+
+# If `MODEL_DIR` is set and is a valid directory
+if [[ -n "${MODEL_DIR:-}" ]]; then
+    if [[ ! -d "${MODEL_DIR}" ]]; then
+        echo "ERROR: Provided MODEL_DIR is not a valid directory" >&2
+        exit 1
+    fi
+
+    # Check if `requirements.txt` exists and if so install dependencies
+    if [[ -f "${MODEL_DIR}/requirements.txt" ]]; then
+        echo "INFO: Installing custom dependencies from ${MODEL_DIR}/requirements.txt"
+        uv pip install --active -r "${MODEL_DIR}/requirements.txt" --no-cache-dir
+
+        # Check if the custom handler file is missing when `requirements.txt` is present
+        if [[ ! -f "${MODEL_DIR}/${CUSTOM_HANDLER_FILE}" ]]; then
+            echo "WARNING: requirements.txt is present, but ${CUSTOM_HANDLER_FILE} is missing in ${MODEL_DIR}."
+            echo "WARNING: If you intend to run custom code, make sure to include ${CUSTOM_HANDLER_FILE}."
+        fi
+    fi
+fi
+
+exec hf-serve "$@"

--- a/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
+++ b/containers/pytorch/inference/gpu/2.11.0/transformers/5.13.1/py311/entrypoint.sh
@@ -7,13 +7,12 @@ if ! command -v nvidia-smi &>/dev/null; then
     exit 1
 fi
 
-export CLOUD="google"
-
 # Default `PORT` is 5000, unless other port is provided via `AIP_HTTP_PORT` only
 # when `AIP_MODE` is set (usually set to `PREDICT`)
 readonly DEFAULT_PORT=5000
 if [[ ! -z "${AIP_MODE}" ]]; then
     export PORT="${AIP_HTTP_PORT:-$DEFAULT_PORT}"
+    export CLOUD="google"
 else
     export PORT="$DEFAULT_PORT"
 fi

--- a/containers/pytorch/training/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/training/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -59,8 +59,10 @@ ENV VIRTUAL_ENV=/home/huggingface/venv \
 RUN uv pip install "torch==2.11.0" torchvision torchaudio --torch-backend=cu126
 
 RUN uv pip install --no-cache-dir \
-    "transformers[audio,chat_template,kernels,video,vision]>=5.13.1"
-    "huggingface_hub[hf_xet]==1.23.0" \
+    "transformers[audio,chat_template,kernels,video,vision]==5.13.1" \
+    "diffusers[training]==0.39.0" \
+    "sentence-transformers[train]==5.6.0" \
+    "huggingface_hub==1.23.0" \
     "datasets==5.0.0" \
     "teich==0.1.5" \
     "accelerate==1.14.0" \

--- a/containers/pytorch/training/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/training/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -1,0 +1,75 @@
+FROM nvidia/cuda:12.6.3-devel-ubuntu24.04
+LABEL maintainer="Hugging Face"
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    build-essential \
+    git \
+    git-lfs \
+    ffmpeg=7:* \
+    libmagic-dev \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN if ! ldconfig -p | grep -q libnpp; then \
+    apt-get update && apt-get install -y --no-install-recommends libnpp-dev; \
+    fi && \
+    if ! ldconfig -p | grep -q libnvrtc; then \
+    apt-get update && apt-get install -y --no-install-recommends cuda-nvrtc-dev; \
+    fi && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update -y && \
+    apt-get install google-cloud-cli -y && \
+    apt-get clean autoremove --yes && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}
+
+RUN mkdir -p /home/huggingface && \
+    useradd -d /home/huggingface -s /bin/bash huggingface && \
+    chown -R huggingface:huggingface /home/huggingface
+
+RUN mkdir -p /home/huggingface/.triton/autotune && \
+    chown -R huggingface:huggingface /home/huggingface/.triton
+
+ENV HOME=/home/huggingface
+USER huggingface
+WORKDIR /home/huggingface
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/huggingface/.cargo/bin:/home/huggingface/.local/bin/:$PATH"
+
+RUN uv python install 3.11
+
+RUN uv venv /home/huggingface/venv --python 3.11
+ENV VIRTUAL_ENV=/home/huggingface/venv \
+    PATH="/home/huggingface/venv/bin:$PATH"
+
+RUN uv pip install "torch==2.11.0" torchvision torchaudio --torch-backend=cu126
+
+RUN uv pip install --no-cache-dir \
+    "transformers[audio,chat_template,kernels,video,vision]>=5.13.1"
+    "huggingface_hub[hf_xet]==1.23.0" \
+    "datasets==5.0.0" \
+    "teich==0.1.5" \
+    "accelerate==1.14.0" \
+    "trl[deepspeed,peft,quantization,vlm]==1.8.0"
+
+RUN uv pip install --no-cache-dir \
+    google-cloud-storage \
+    google-cloud-bigquery \
+    google-cloud-aiplatform \
+    google-cloud-pubsub \
+    google-cloud-logging \
+    gcsfs

--- a/containers/pytorch/training/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
+++ b/containers/pytorch/training/gpu/2.11.0/transformers/5.13.1/py311/Dockerfile
@@ -9,13 +9,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     ca-certificates \
     build-essential \
     git \
-    git-lfs \
     ffmpeg=7:* \
     libmagic-dev \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# NOTE: `torchcodec` and hence the audio-related models as e.g. Wav2Vec, require
+# both `libnpp` and `libnvrtc` to be preset for it to work seamlessly on CUDA
 RUN if ! ldconfig -p | grep -q libnpp; then \
     apt-get update && apt-get install -y --no-install-recommends libnpp-dev; \
     fi && \
@@ -34,6 +35,23 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     apt-get install google-cloud-cli -y && \
     apt-get clean autoremove --yes && \
     rm -rf /var/lib/{apt,dpkg,cache,log}
+
+# NOTE: anthoscli is not required for the intended use of gcloud SDK within this
+# context, hence we're safe to remove it, preventing the following CVEs:
+# - CVE-2025-68121
+# - CVE-2026-27143
+# - CVE-2026-33186
+# Which are originated due to the bundled Go version in the pre-compiled anthoscli
+RUN rm -rf /usr/lib/google-cloud-sdk/bin/anthoscli
+
+# NOTE: nic_sampler is not required for inference workloads, and is removed to
+# prevent CVEs originating from the bundled Go version used to compile it
+# - CVE-2025-22871
+# - CVE-2026-33186
+# - CVE-2024-24790
+# - CVE-2026-27143
+# - CVE-2025-68121
+RUN rm -f /opt/nvidia/nsight-compute/2025.1.1/host/target-linux-x64/plugins/efa_metrics/nic_sampler
 
 RUN mkdir -p /home/huggingface && \
     useradd -d /home/huggingface -s /bin/bash huggingface && \
@@ -57,6 +75,18 @@ ENV VIRTUAL_ENV=/home/huggingface/venv \
     PATH="/home/huggingface/venv/bin:$PATH"
 
 RUN uv pip install "torch==2.11.0" torchvision torchaudio --torch-backend=cu126
+
+# CVE-2025-47273: setuptools>=78.1.1
+# CVE-2026-42311, CVE-2026-40192: Pillow>=12.2
+# CVE-2026-26007: cryptography>=46.0.5
+# GHSA-537c-gmf6-5ccf: cryptography>=48.0.1
+# CVE-2026-27459: pyopenssl>=26
+RUN uv pip install \
+    "setuptools>=78.1.1" \
+    "Pillow>=12.2" \
+    "cryptography>=48.0.1" \
+    "pyopenssl>=26" \
+    --upgrade
 
 RUN uv pip install --no-cache-dir \
     "transformers[audio,chat_template,kernels,video,vision]==5.13.1" \


### PR DESCRIPTION
## Description

This PR adds the latest versions for both PyTorch Training and PyTorch Inference DLCs.

The PyTorch Training DLC is an iteration of the former container included in https://github.com/huggingface/Google-Cloud-Containers/pull/151 but never released, which incorporates some changes and fixes as identified after https://github.com/huggingface/Google-Cloud-Containers/pull/162.

And the PyTorch Inference DLC comes with the latest [`hf-serve`](https://github.com/huggingface/hf-serve) release (already made public so no need for a custom wheel), and comes with the latest versions of the Hugging Face libraries as Transformers, Diffusers, or Sentence Transformers; and also bumps Transformers > 5 meaning that some pipelines as `question-answering`, `summarization`, etc. are gone in favour of `text-generation`, and the rest of the features, optimizations, fixes, model releases, etc. that were included since v4. Read more about it at https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md.